### PR TITLE
Backend experimentation

### DIFF
--- a/bench.mojo
+++ b/bench.mojo
@@ -1,7 +1,7 @@
 from numojo import *
 import benchmark
 from benchmark.compiler import keep
-from numojo._math_funcs import Vectorized
+from numojo._math_funcs import Vectorized, Naive, Parallelized
 alias backend = Vectorized
 fn main():
     var tens1:Tensor[DType.float32] = Tensor[DType.float32](100,100)
@@ -27,63 +27,63 @@ fn main():
             keep(res.data())
         except:
             print('mod: Failed shape error')
-    # var report_mod = benchmark.run[test_mod]()
-    # print('mod f32 100x100')
-    # report_mod.print()
-    # fn test_mul()capturing:
-    #     try:
-    #         res = mul[DType.float32,backend=backend](tens1, tens2)
-    #         keep(res.data())
-    #     except:
-    #         print('mul: Failed shape error')
-    # var report_mul = benchmark.run[test_mul]()
-    # print('mul f32 100x100')
-    # report_mul.print()
-    # fn test_sub()capturing:
-    #     try:
-    #         res = sub[DType.float32,backend=backend](tens1, tens2)
-    #         keep(res.data())
-    #     except:
-    #         print('sub: Failed shape error')
-    # var report_sub = benchmark.run[test_sub]()
-    # print('sub f32 100x100')
-    # report_sub.print()
-    # fn test_add()capturing:
-    #     try:
-    #         res = add[DType.float32,backend=backend](tens1, tens2)
-    #         keep(res.data())
-    #     except:
-    #         print('add: Failed shape error')
-    # var report_add = benchmark.run[test_add]()
-    # print('add f32 100x100')
-    # report_add.print()
-    # fn test_div()capturing:
-    #     try:
-    #         res = div[DType.float32,backend=backend](tens1, tens2)
-    #         keep(res.data())
-    #     except:
-    #         print('div: Failed shape error')
-    # var report_div = benchmark.run[test_div]()
-    # print('div f32 100x100')
-    # report_div.print()
-    # fn test_copysign()capturing:
-    #     try:
-    #         res = copysign[DType.float32,backend=backend](tens1, tens2)
-    #         keep(res.data())
-    #     except:
-    #         print('copysign: Failed shape error')
-    # var report_copysign = benchmark.run[test_copysign]()
-    # print('copysign f32 100x100')
-    # report_copysign.print()
-    # fn test_atan2()capturing:
-    #     try:
-    #         res = atan2[DType.float32,backend=backend](tens1, tens2)
-    #         keep(res.data())
-    #     except:
-    #         print('atan2: Failed shape error')
-    # var report_atan2 = benchmark.run[test_atan2]()
-    # print('atan2 f32 100x100')
-    # report_atan2.print()
+    var report_mod = benchmark.run[test_mod]()
+    print('mod f32 100x100')
+    report_mod.print()
+    fn test_mul()capturing:
+        try:
+            res = mul[DType.float32,backend=backend](tens1, tens2)
+            keep(res.data())
+        except:
+            print('mul: Failed shape error')
+    var report_mul = benchmark.run[test_mul]()
+    print('mul f32 100x100')
+    report_mul.print()
+    fn test_sub()capturing:
+        try:
+            res = sub[DType.float32,backend=backend](tens1, tens2)
+            keep(res.data())
+        except:
+            print('sub: Failed shape error')
+    var report_sub = benchmark.run[test_sub]()
+    print('sub f32 100x100')
+    report_sub.print()
+    fn test_add()capturing:
+        try:
+            res = add[DType.float32,backend=backend](tens1, tens2)
+            keep(res.data())
+        except:
+            print('add: Failed shape error')
+    var report_add = benchmark.run[test_add]()
+    print('add f32 100x100')
+    report_add.print()
+    fn test_div()capturing:
+        try:
+            res = div[DType.float32,backend=backend](tens1, tens2)
+            keep(res.data())
+        except:
+            print('div: Failed shape error')
+    var report_div = benchmark.run[test_div]()
+    print('div f32 100x100')
+    report_div.print()
+    fn test_copysign()capturing:
+        try:
+            res = copysign[DType.float32,backend=backend](tens1, tens2)
+            keep(res.data())
+        except:
+            print('copysign: Failed shape error')
+    var report_copysign = benchmark.run[test_copysign]()
+    print('copysign f32 100x100')
+    report_copysign.print()
+    fn test_atan2()capturing:
+        try:
+            res = atan2[DType.float32,backend=backend](tens1, tens2)
+            keep(res.data())
+        except:
+            print('atan2: Failed shape error')
+    var report_atan2 = benchmark.run[test_atan2]()
+    print('atan2 f32 100x100')
+    report_atan2.print()
     fn test_hypot()capturing:
         try:
             res = hypot[DType.float32,backend=backend](tens1, tens2)
@@ -102,234 +102,234 @@ fn main():
     var report_hypot_fma = benchmark.run[test_hypot_fma]()
     print('hypot_fma f32 100x100')
     report_hypot_fma.print()
-    # fn test_nextafter()capturing:
-    #     try:
-    #         res = nextafter[DType.float32,backend=backend](tens1, tens2)
-    #         keep(res.data())
-    #     except:
-    #         print('nextafter: Failed shape error')
-    # var report_nextafter = benchmark.run[test_nextafter]()
-    # print('nextafter f32 100x100')
-    # report_nextafter.print()
-    # fn test_scalb()capturing:
-    #     try:
-    #         res = scalb[DType.float32,backend=backend](tens1, tens2)
-    #         keep(res.data())
-    #     except:
-    #         print('scalb: Failed shape error')
-    # var report_scalb = benchmark.run[test_scalb]()
-    # print('scalb f32 100x100')
-    # report_scalb.print()
-    # fn test_remainder()capturing:
-    #     try:
-    #         res = remainder[DType.float32,backend=backend](tens1, tens2)
-    #         keep(res.data())
-    #     except:
-    #         print('remainder: Failed shape error')
-    # var report_remainder = benchmark.run[test_remainder]()
-    # print('remainder f32 100x100')
-    # report_remainder.print()
-    # var tens:Tensor[DType.float32] = Tensor[DType.float32](100,100)
-    # for i in range(10_000):
-    #     tens[i]= SIMD[DType.float32,1](3.141592/4)
-    # fn test_abs()capturing:
-    #     res = abs[DType.float32,backend=backend](tens)
+    fn test_nextafter()capturing:
+        try:
+            res = nextafter[DType.float32,backend=backend](tens1, tens2)
+            keep(res.data())
+        except:
+            print('nextafter: Failed shape error')
+    var report_nextafter = benchmark.run[test_nextafter]()
+    print('nextafter f32 100x100')
+    report_nextafter.print()
+    fn test_scalb()capturing:
+        try:
+            res = scalb[DType.float32,backend=backend](tens1, tens2)
+            keep(res.data())
+        except:
+            print('scalb: Failed shape error')
+    var report_scalb = benchmark.run[test_scalb]()
+    print('scalb f32 100x100')
+    report_scalb.print()
+    fn test_remainder()capturing:
+        try:
+            res = remainder[DType.float32,backend=backend](tens1, tens2)
+            keep(res.data())
+        except:
+            print('remainder: Failed shape error')
+    var report_remainder = benchmark.run[test_remainder]()
+    print('remainder f32 100x100')
+    report_remainder.print()
+    var tens:Tensor[DType.float32] = Tensor[DType.float32](100,100)
+    for i in range(10_000):
+        tens[i]= SIMD[DType.float32,1](3.141592/4)
+    fn test_abs()capturing:
+        res = abs[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_abs = benchmark.run[test_abs]()
+    print('abs f32 100x100')
+    report_abs.print()
+    fn test_floor()capturing:
+        res = floor[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_floor = benchmark.run[test_floor]()
+    print('floor f32 100x100')
+    report_floor.print()
+    fn test_ceil()capturing:
+        res = ceil[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_ceil = benchmark.run[test_ceil]()
+    print('ceil f32 100x100')
+    report_ceil.print()
+    fn test_trunc()capturing:
+        res = trunc[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_trunc = benchmark.run[test_trunc]()
+    print('trunc f32 100x100')
+    report_trunc.print()
+    fn test_round()capturing:
+        res = round[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_round = benchmark.run[test_round]()
+    print('round f32 100x100')
+    report_round.print()
+    fn test_roundeven()capturing:
+        res = roundeven[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_roundeven = benchmark.run[test_roundeven]()
+    print('roundeven f32 100x100')
+    report_roundeven.print()
+    fn test_round_half_down()capturing:
+        res = round_half_down[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_round_half_down = benchmark.run[test_round_half_down]()
+    print('round_half_down f32 100x100')
+    report_round_half_down.print()
+    fn test_round_half_up()capturing:
+        res = round_half_up[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_round_half_up = benchmark.run[test_round_half_up]()
+    print('round_half_up f32 100x100')
+    report_round_half_up.print()
+    fn test_rsqrt()capturing:
+        res = rsqrt[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_rsqrt = benchmark.run[test_rsqrt]()
+    print('rsqrt f32 100x100')
+    report_rsqrt.print()
+    fn test_sqrt()capturing:
+        res = sqrt[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_sqrt = benchmark.run[test_sqrt]()
+    print('sqrt f32 100x100')
+    report_sqrt.print()
+    fn test_exp2()capturing:
+        res = exp2[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_exp2 = benchmark.run[test_exp2]()
+    print('exp2 f32 100x100')
+    report_exp2.print()
+    fn test_exp()capturing:
+        res = exp[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_exp = benchmark.run[test_exp]()
+    print('exp f32 100x100')
+    report_exp.print()
+    fn test_log()capturing:
+        res = log[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_log = benchmark.run[test_log]()
+    print('log f32 100x100')
+    report_log.print()
+    fn test_log2()capturing:
+        res = log2[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_log2 = benchmark.run[test_log2]()
+    print('log2 f32 100x100')
+    report_log2.print()
+    # fn test_erf()capturing:
+    #     res = erf[DType.float32,backend=backend](tens)
     #     keep(res.data())
-    # var report_abs = benchmark.run[test_abs]()
-    # print('abs f32 100x100')
-    # report_abs.print()
-    # fn test_floor()capturing:
-    #     res = floor[DType.float32,backend=backend](tens)
+    # var report_erf = benchmark.run[test_erf]()
+    # print('erf f32 100x100')
+    # report_erf.print()
+    fn test_tanh()capturing:
+        res = tanh[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_tanh = benchmark.run[test_tanh]()
+    print('tanh f32 100x100')
+    report_tanh.print()
+    fn test_reciprocal()capturing:
+        res = reciprocal[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_reciprocal = benchmark.run[test_reciprocal]()
+    print('reciprocal f32 100x100')
+    report_reciprocal.print()
+    # fn test_identity()capturing:
+    #     res = identity[DType.float32,backend=backend](tens)
     #     keep(res.data())
-    # var report_floor = benchmark.run[test_floor]()
-    # print('floor f32 100x100')
-    # report_floor.print()
-    # fn test_ceil()capturing:
-    #     res = ceil[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_ceil = benchmark.run[test_ceil]()
-    # print('ceil f32 100x100')
-    # report_ceil.print()
-    # fn test_trunc()capturing:
-    #     res = trunc[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_trunc = benchmark.run[test_trunc]()
-    # print('trunc f32 100x100')
-    # report_trunc.print()
-    # fn test_round()capturing:
-    #     res = round[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_round = benchmark.run[test_round]()
-    # print('round f32 100x100')
-    # report_round.print()
-    # fn test_roundeven()capturing:
-    #     res = roundeven[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_roundeven = benchmark.run[test_roundeven]()
-    # print('roundeven f32 100x100')
-    # report_roundeven.print()
-    # fn test_round_half_down()capturing:
-    #     res = round_half_down[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_round_half_down = benchmark.run[test_round_half_down]()
-    # print('round_half_down f32 100x100')
-    # report_round_half_down.print()
-    # fn test_round_half_up()capturing:
-    #     res = round_half_up[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_round_half_up = benchmark.run[test_round_half_up]()
-    # print('round_half_up f32 100x100')
-    # report_round_half_up.print()
-    # fn test_rsqrt()capturing:
-    #     res = rsqrt[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_rsqrt = benchmark.run[test_rsqrt]()
-    # print('rsqrt f32 100x100')
-    # report_rsqrt.print()
-    # fn test_sqrt()capturing:
-    #     res = sqrt[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_sqrt = benchmark.run[test_sqrt]()
-    # print('sqrt f32 100x100')
-    # report_sqrt.print()
-    # fn test_exp2()capturing:
-    #     res = exp2[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_exp2 = benchmark.run[test_exp2]()
-    # print('exp2 f32 100x100')
-    # report_exp2.print()
-    # fn test_exp()capturing:
-    #     res = exp[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_exp = benchmark.run[test_exp]()
-    # print('exp f32 100x100')
-    # report_exp.print()
-    # fn test_log()capturing:
-    #     res = log[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_log = benchmark.run[test_log]()
-    # print('log f32 100x100')
-    # report_log.print()
-    # fn test_log2()capturing:
-    #     res = log2[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_log2 = benchmark.run[test_log2]()
-    # print('log2 f32 100x100')
-    # report_log2.print()
-    # # fn test_erf()capturing:
-    # #     res = erf[DType.float32,backend=backend](tens)
-    # #     keep(res.data())
-    # # var report_erf = benchmark.run[test_erf]()
-    # # print('erf f32 100x100')
-    # # report_erf.print()
-    # fn test_tanh()capturing:
-    #     res = tanh[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_tanh = benchmark.run[test_tanh]()
-    # print('tanh f32 100x100')
-    # report_tanh.print()
-    # fn test_reciprocal()capturing:
-    #     res = reciprocal[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_reciprocal = benchmark.run[test_reciprocal]()
-    # print('reciprocal f32 100x100')
-    # report_reciprocal.print()
-    # # fn test_identity()capturing:
-    # #     res = identity[DType.float32,backend=backend](tens)
-    # #     keep(res.data())
-    # # var report_identity = benchmark.run[test_identity]()
-    # # print('identity f32 100x100')
-    # # report_identity.print()
-    # fn test_acos()capturing:
-    #     res = acos[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_acos = benchmark.run[test_acos]()
-    # print('acos f32 100x100')
-    # report_acos.print()
-    # fn test_asin()capturing:
-    #     res = asin[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_asin = benchmark.run[test_asin]()
-    # print('asin f32 100x100')
-    # report_asin.print()
-    # fn test_atan()capturing:
-    #     res = atan[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_atan = benchmark.run[test_atan]()
-    # print('atan f32 100x100')
-    # report_atan.print()
-    # fn test_cos()capturing:
-    #     res = cos[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_cos = benchmark.run[test_cos]()
-    # print('cos f32 100x100')
-    # report_cos.print()
-    # fn test_sin()capturing:
-    #     res = sin[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_sin = benchmark.run[test_sin]()
-    # print('sin f32 100x100')
-    # report_sin.print()
-    # fn test_tan()capturing:
-    #     res = tan[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_tan = benchmark.run[test_tan]()
-    # print('tan f32 100x100')
-    # report_tan.print()
-    # fn test_acosh()capturing:
-    #     res = acosh[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_acosh = benchmark.run[test_acosh]()
-    # print('acosh f32 100x100')
-    # report_acosh.print()
-    # fn test_asinh()capturing:
-    #     res = asinh[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_asinh = benchmark.run[test_asinh]()
-    # print('asinh f32 100x100')
-    # report_asinh.print()
-    # fn test_atanh()capturing:
-    #     res = atanh[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_atanh = benchmark.run[test_atanh]()
-    # print('atanh f32 100x100')
-    # report_atanh.print()
-    # fn test_cosh()capturing:
-    #     res = cosh[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_cosh = benchmark.run[test_cosh]()
-    # print('cosh f32 100x100')
-    # report_cosh.print()
-    # fn test_sinh()capturing:
-    #     res = sinh[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_sinh = benchmark.run[test_sinh]()
-    # print('sinh f32 100x100')
-    # report_sinh.print()
-    # fn test_expm1()capturing:
-    #     res = expm1[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_expm1 = benchmark.run[test_expm1]()
-    # print('expm1 f32 100x100')
-    # report_expm1.print()
-    # fn test_log10()capturing:
-    #     res = log10[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_log10 = benchmark.run[test_log10]()
-    # print('log10 f32 100x100')
-    # report_log10.print()
-    # fn test_log1p()capturing:
-    #     res = log1p[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_log1p = benchmark.run[test_log1p]()
-    # print('log1p f32 100x100')
-    # report_log1p.print()
-    # fn test_cbrt()capturing:
-    #     res = cbrt[DType.float32,backend=backend](tens)
-    #     keep(res.data())
-    # var report_cbrt = benchmark.run[test_cbrt]()
-    # print('cbrt f32 100x100')
-    # report_cbrt.print()
+    # var report_identity = benchmark.run[test_identity]()
+    # print('identity f32 100x100')
+    # report_identity.print()
+    fn test_acos()capturing:
+        res = acos[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_acos = benchmark.run[test_acos]()
+    print('acos f32 100x100')
+    report_acos.print()
+    fn test_asin()capturing:
+        res = asin[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_asin = benchmark.run[test_asin]()
+    print('asin f32 100x100')
+    report_asin.print()
+    fn test_atan()capturing:
+        res = atan[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_atan = benchmark.run[test_atan]()
+    print('atan f32 100x100')
+    report_atan.print()
+    fn test_cos()capturing:
+        res = cos[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_cos = benchmark.run[test_cos]()
+    print('cos f32 100x100')
+    report_cos.print()
+    fn test_sin()capturing:
+        res = sin[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_sin = benchmark.run[test_sin]()
+    print('sin f32 100x100')
+    report_sin.print()
+    fn test_tan()capturing:
+        res = tan[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_tan = benchmark.run[test_tan]()
+    print('tan f32 100x100')
+    report_tan.print()
+    fn test_acosh()capturing:
+        res = acosh[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_acosh = benchmark.run[test_acosh]()
+    print('acosh f32 100x100')
+    report_acosh.print()
+    fn test_asinh()capturing:
+        res = asinh[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_asinh = benchmark.run[test_asinh]()
+    print('asinh f32 100x100')
+    report_asinh.print()
+    fn test_atanh()capturing:
+        res = atanh[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_atanh = benchmark.run[test_atanh]()
+    print('atanh f32 100x100')
+    report_atanh.print()
+    fn test_cosh()capturing:
+        res = cosh[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_cosh = benchmark.run[test_cosh]()
+    print('cosh f32 100x100')
+    report_cosh.print()
+    fn test_sinh()capturing:
+        res = sinh[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_sinh = benchmark.run[test_sinh]()
+    print('sinh f32 100x100')
+    report_sinh.print()
+    fn test_expm1()capturing:
+        res = expm1[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_expm1 = benchmark.run[test_expm1]()
+    print('expm1 f32 100x100')
+    report_expm1.print()
+    fn test_log10()capturing:
+        res = log10[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_log10 = benchmark.run[test_log10]()
+    print('log10 f32 100x100')
+    report_log10.print()
+    fn test_log1p()capturing:
+        res = log1p[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_log1p = benchmark.run[test_log1p]()
+    print('log1p f32 100x100')
+    report_log1p.print()
+    fn test_cbrt()capturing:
+        res = cbrt[DType.float32,backend=backend](tens)
+        keep(res.data())
+    var report_cbrt = benchmark.run[test_cbrt]()
+    print('cbrt f32 100x100')
+    report_cbrt.print()
     # fn test_erfc()capturing:
     #     res = erfc[DType.float32,backend=backend](tens)
     #     keep(res.data())

--- a/bench.mojo
+++ b/bench.mojo
@@ -1,363 +1,391 @@
 from numojo import *
 import benchmark
 from benchmark.compiler import keep
+from numojo._math_funcs import Vectorized
+alias backend = Vectorized
 fn main():
     var tens1:Tensor[DType.float32] = Tensor[DType.float32](100,100)
     var tens2:Tensor[DType.float32] = Tensor[DType.float32](100,100)
+    var tens3:Tensor[DType.float32] = Tensor[DType.float32](100,100)
     for i in range(10_000):
         tens1[i]= SIMD[DType.float32,1](3.141592/4)
         tens2[i]= SIMD[DType.float32,1](3.141592)
+        tens3[i] = SIMD[DType.float32,1](3.141592/2)
     var res:Tensor[DType.float32]
+    fn test_fma()capturing:
+        try:
+            res = fma[DType.float32,backend=backend](tens1, tens2, tens3)
+            keep(res.data())
+        except:
+            print('fma: Failed shape error')
+    var report_fma = benchmark.run[test_fma]()
+    print('fma f32 100x100')
+    report_fma.print()
     fn test_mod()capturing:
         try:
-            res = mod[DType.float32](tens1, tens2)
+            res = mod[DType.float32,backend=backend](tens1, tens2)
             keep(res.data())
         except:
             print('mod: Failed shape error')
-    var report_mod = benchmark.run[test_mod]()
-    print('mod f32 100x100')
-    report_mod.print()
-    fn test_mul()capturing:
-        try:
-            res = mul[DType.float32](tens1, tens2)
-            keep(res.data())
-        except:
-            print('mul: Failed shape error')
-    var report_mul = benchmark.run[test_mul]()
-    print('mul f32 100x100')
-    report_mul.print()
-    fn test_sub()capturing:
-        try:
-            res = sub[DType.float32](tens1, tens2)
-            keep(res.data())
-        except:
-            print('sub: Failed shape error')
-    var report_sub = benchmark.run[test_sub]()
-    print('sub f32 100x100')
-    report_sub.print()
-    fn test_add()capturing:
-        try:
-            res = add[DType.float32](tens1, tens2)
-            keep(res.data())
-        except:
-            print('add: Failed shape error')
-    var report_add = benchmark.run[test_add]()
-    print('add f32 100x100')
-    report_add.print()
-    fn test_div()capturing:
-        try:
-            res = div[DType.float32](tens1, tens2)
-            keep(res.data())
-        except:
-            print('div: Failed shape error')
-    var report_div = benchmark.run[test_div]()
-    print('div f32 100x100')
-    report_div.print()
-    fn test_copysign()capturing:
-        try:
-            res = copysign[DType.float32](tens1, tens2)
-            keep(res.data())
-        except:
-            print('copysign: Failed shape error')
-    var report_copysign = benchmark.run[test_copysign]()
-    print('copysign f32 100x100')
-    report_copysign.print()
-    fn test_atan2()capturing:
-        try:
-            res = atan2[DType.float32](tens1, tens2)
-            keep(res.data())
-        except:
-            print('atan2: Failed shape error')
-    var report_atan2 = benchmark.run[test_atan2]()
-    print('atan2 f32 100x100')
-    report_atan2.print()
+    # var report_mod = benchmark.run[test_mod]()
+    # print('mod f32 100x100')
+    # report_mod.print()
+    # fn test_mul()capturing:
+    #     try:
+    #         res = mul[DType.float32,backend=backend](tens1, tens2)
+    #         keep(res.data())
+    #     except:
+    #         print('mul: Failed shape error')
+    # var report_mul = benchmark.run[test_mul]()
+    # print('mul f32 100x100')
+    # report_mul.print()
+    # fn test_sub()capturing:
+    #     try:
+    #         res = sub[DType.float32,backend=backend](tens1, tens2)
+    #         keep(res.data())
+    #     except:
+    #         print('sub: Failed shape error')
+    # var report_sub = benchmark.run[test_sub]()
+    # print('sub f32 100x100')
+    # report_sub.print()
+    # fn test_add()capturing:
+    #     try:
+    #         res = add[DType.float32,backend=backend](tens1, tens2)
+    #         keep(res.data())
+    #     except:
+    #         print('add: Failed shape error')
+    # var report_add = benchmark.run[test_add]()
+    # print('add f32 100x100')
+    # report_add.print()
+    # fn test_div()capturing:
+    #     try:
+    #         res = div[DType.float32,backend=backend](tens1, tens2)
+    #         keep(res.data())
+    #     except:
+    #         print('div: Failed shape error')
+    # var report_div = benchmark.run[test_div]()
+    # print('div f32 100x100')
+    # report_div.print()
+    # fn test_copysign()capturing:
+    #     try:
+    #         res = copysign[DType.float32,backend=backend](tens1, tens2)
+    #         keep(res.data())
+    #     except:
+    #         print('copysign: Failed shape error')
+    # var report_copysign = benchmark.run[test_copysign]()
+    # print('copysign f32 100x100')
+    # report_copysign.print()
+    # fn test_atan2()capturing:
+    #     try:
+    #         res = atan2[DType.float32,backend=backend](tens1, tens2)
+    #         keep(res.data())
+    #     except:
+    #         print('atan2: Failed shape error')
+    # var report_atan2 = benchmark.run[test_atan2]()
+    # print('atan2 f32 100x100')
+    # report_atan2.print()
     fn test_hypot()capturing:
         try:
-            res = hypot[DType.float32](tens1, tens2)
+            res = hypot[DType.float32,backend=backend](tens1, tens2)
             keep(res.data())
         except:
             print('hypot: Failed shape error')
     var report_hypot = benchmark.run[test_hypot]()
     print('hypot f32 100x100')
     report_hypot.print()
-    fn test_nextafter()capturing:
+    fn test_hypot_fma()capturing:
         try:
-            res = nextafter[DType.float32](tens1, tens2)
+            res = hypot_fma[DType.float32,backend=backend](tens1, tens2)
             keep(res.data())
         except:
-            print('nextafter: Failed shape error')
-    var report_nextafter = benchmark.run[test_nextafter]()
-    print('nextafter f32 100x100')
-    report_nextafter.print()
-    fn test_scalb()capturing:
-        try:
-            res = scalb[DType.float32](tens1, tens2)
-            keep(res.data())
-        except:
-            print('scalb: Failed shape error')
-    var report_scalb = benchmark.run[test_scalb]()
-    print('scalb f32 100x100')
-    report_scalb.print()
-    fn test_remainder()capturing:
-        try:
-            res = remainder[DType.float32](tens1, tens2)
-            keep(res.data())
-        except:
-            print('remainder: Failed shape error')
-    var report_remainder = benchmark.run[test_remainder]()
-    print('remainder f32 100x100')
-    report_remainder.print()
-    var tens:Tensor[DType.float32] = Tensor[DType.float32](100,100)
-    for i in range(10_000):
-        tens[i]= SIMD[DType.float32,1](3.141592/4)
-    fn test_abs()capturing:
-        res = abs[DType.float32](tens)
-        keep(res.data())
-    var report_abs = benchmark.run[test_abs]()
-    print('abs f32 100x100')
-    report_abs.print()
-    fn test_floor()capturing:
-        res = floor[DType.float32](tens)
-        keep(res.data())
-    var report_floor = benchmark.run[test_floor]()
-    print('floor f32 100x100')
-    report_floor.print()
-    fn test_ceil()capturing:
-        res = ceil[DType.float32](tens)
-        keep(res.data())
-    var report_ceil = benchmark.run[test_ceil]()
-    print('ceil f32 100x100')
-    report_ceil.print()
-    fn test_trunc()capturing:
-        res = trunc[DType.float32](tens)
-        keep(res.data())
-    var report_trunc = benchmark.run[test_trunc]()
-    print('trunc f32 100x100')
-    report_trunc.print()
-    fn test_round()capturing:
-        res = round[DType.float32](tens)
-        keep(res.data())
-    var report_round = benchmark.run[test_round]()
-    print('round f32 100x100')
-    report_round.print()
-    fn test_roundeven()capturing:
-        res = roundeven[DType.float32](tens)
-        keep(res.data())
-    var report_roundeven = benchmark.run[test_roundeven]()
-    print('roundeven f32 100x100')
-    report_roundeven.print()
-    fn test_round_half_down()capturing:
-        res = round_half_down[DType.float32](tens)
-        keep(res.data())
-    var report_round_half_down = benchmark.run[test_round_half_down]()
-    print('round_half_down f32 100x100')
-    report_round_half_down.print()
-    fn test_round_half_up()capturing:
-        res = round_half_up[DType.float32](tens)
-        keep(res.data())
-    var report_round_half_up = benchmark.run[test_round_half_up]()
-    print('round_half_up f32 100x100')
-    report_round_half_up.print()
-    fn test_rsqrt()capturing:
-        res = rsqrt[DType.float32](tens)
-        keep(res.data())
-    var report_rsqrt = benchmark.run[test_rsqrt]()
-    print('rsqrt f32 100x100')
-    report_rsqrt.print()
-    fn test_exp2()capturing:
-        res = exp2[DType.float32](tens)
-        keep(res.data())
-    var report_exp2 = benchmark.run[test_exp2]()
-    print('exp2 f32 100x100')
-    report_exp2.print()
-    fn test_exp()capturing:
-        res = exp[DType.float32](tens)
-        keep(res.data())
-    var report_exp = benchmark.run[test_exp]()
-    print('exp f32 100x100')
-    report_exp.print()
-    fn test_log()capturing:
-        res = log[DType.float32](tens)
-        keep(res.data())
-    var report_log = benchmark.run[test_log]()
-    print('log f32 100x100')
-    report_log.print()
-    fn test_log2()capturing:
-        res = log2[DType.float32](tens)
-        keep(res.data())
-    var report_log2 = benchmark.run[test_log2]()
-    print('log2 f32 100x100')
-    report_log2.print()
-    # fn test_erf()capturing:
-    #     res = erf[DType.float32](tens)
+            print('hypot: Failed shape error')
+    var report_hypot_fma = benchmark.run[test_hypot_fma]()
+    print('hypot_fma f32 100x100')
+    report_hypot_fma.print()
+    # fn test_nextafter()capturing:
+    #     try:
+    #         res = nextafter[DType.float32,backend=backend](tens1, tens2)
+    #         keep(res.data())
+    #     except:
+    #         print('nextafter: Failed shape error')
+    # var report_nextafter = benchmark.run[test_nextafter]()
+    # print('nextafter f32 100x100')
+    # report_nextafter.print()
+    # fn test_scalb()capturing:
+    #     try:
+    #         res = scalb[DType.float32,backend=backend](tens1, tens2)
+    #         keep(res.data())
+    #     except:
+    #         print('scalb: Failed shape error')
+    # var report_scalb = benchmark.run[test_scalb]()
+    # print('scalb f32 100x100')
+    # report_scalb.print()
+    # fn test_remainder()capturing:
+    #     try:
+    #         res = remainder[DType.float32,backend=backend](tens1, tens2)
+    #         keep(res.data())
+    #     except:
+    #         print('remainder: Failed shape error')
+    # var report_remainder = benchmark.run[test_remainder]()
+    # print('remainder f32 100x100')
+    # report_remainder.print()
+    # var tens:Tensor[DType.float32] = Tensor[DType.float32](100,100)
+    # for i in range(10_000):
+    #     tens[i]= SIMD[DType.float32,1](3.141592/4)
+    # fn test_abs()capturing:
+    #     res = abs[DType.float32,backend=backend](tens)
     #     keep(res.data())
-    # var report_erf = benchmark.run[test_erf]()
-    # print('erf f32 100x100')
-    # report_erf.print()
-    fn test_tanh()capturing:
-        res = tanh[DType.float32](tens)
-        keep(res.data())
-    var report_tanh = benchmark.run[test_tanh]()
-    print('tanh f32 100x100')
-    report_tanh.print()
-    fn test_reciprocal()capturing:
-        res = reciprocal[DType.float32](tens)
-        keep(res.data())
-    var report_reciprocal = benchmark.run[test_reciprocal]()
-    print('reciprocal f32 100x100')
-    report_reciprocal.print()
-    # fn test_identity()capturing:
-    #     res = identity[DType.float32](tens)
+    # var report_abs = benchmark.run[test_abs]()
+    # print('abs f32 100x100')
+    # report_abs.print()
+    # fn test_floor()capturing:
+    #     res = floor[DType.float32,backend=backend](tens)
     #     keep(res.data())
-    # var report_identity = benchmark.run[test_identity]()
-    # print('identity f32 100x100')
-    # report_identity.print()
-    fn test_acos()capturing:
-        res = acos[DType.float32](tens)
-        keep(res.data())
-    var report_acos = benchmark.run[test_acos]()
-    print('acos f32 100x100')
-    report_acos.print()
-    fn test_asin()capturing:
-        res = asin[DType.float32](tens)
-        keep(res.data())
-    var report_asin = benchmark.run[test_asin]()
-    print('asin f32 100x100')
-    report_asin.print()
-    fn test_atan()capturing:
-        res = atan[DType.float32](tens)
-        keep(res.data())
-    var report_atan = benchmark.run[test_atan]()
-    print('atan f32 100x100')
-    report_atan.print()
-    fn test_cos()capturing:
-        res = cos[DType.float32](tens)
-        keep(res.data())
-    var report_cos = benchmark.run[test_cos]()
-    print('cos f32 100x100')
-    report_cos.print()
-    fn test_sin()capturing:
-        res = sin[DType.float32](tens)
-        keep(res.data())
-    var report_sin = benchmark.run[test_sin]()
-    print('sin f32 100x100')
-    report_sin.print()
-    fn test_tan()capturing:
-        res = tan[DType.float32](tens)
-        keep(res.data())
-    var report_tan = benchmark.run[test_tan]()
-    print('tan f32 100x100')
-    report_tan.print()
-    fn test_acosh()capturing:
-        res = acosh[DType.float32](tens)
-        keep(res.data())
-    var report_acosh = benchmark.run[test_acosh]()
-    print('acosh f32 100x100')
-    report_acosh.print()
-    fn test_asinh()capturing:
-        res = asinh[DType.float32](tens)
-        keep(res.data())
-    var report_asinh = benchmark.run[test_asinh]()
-    print('asinh f32 100x100')
-    report_asinh.print()
-    fn test_atanh()capturing:
-        res = atanh[DType.float32](tens)
-        keep(res.data())
-    var report_atanh = benchmark.run[test_atanh]()
-    print('atanh f32 100x100')
-    report_atanh.print()
-    fn test_cosh()capturing:
-        res = cosh[DType.float32](tens)
-        keep(res.data())
-    var report_cosh = benchmark.run[test_cosh]()
-    print('cosh f32 100x100')
-    report_cosh.print()
-    fn test_sinh()capturing:
-        res = sinh[DType.float32](tens)
-        keep(res.data())
-    var report_sinh = benchmark.run[test_sinh]()
-    print('sinh f32 100x100')
-    report_sinh.print()
-    fn test_expm1()capturing:
-        res = expm1[DType.float32](tens)
-        keep(res.data())
-    var report_expm1 = benchmark.run[test_expm1]()
-    print('expm1 f32 100x100')
-    report_expm1.print()
-    fn test_log10()capturing:
-        res = log10[DType.float32](tens)
-        keep(res.data())
-    var report_log10 = benchmark.run[test_log10]()
-    print('log10 f32 100x100')
-    report_log10.print()
-    fn test_log1p()capturing:
-        res = log1p[DType.float32](tens)
-        keep(res.data())
-    var report_log1p = benchmark.run[test_log1p]()
-    print('log1p f32 100x100')
-    report_log1p.print()
-    fn test_cbrt()capturing:
-        res = cbrt[DType.float32](tens)
-        keep(res.data())
-    var report_cbrt = benchmark.run[test_cbrt]()
-    print('cbrt f32 100x100')
-    report_cbrt.print()
+    # var report_floor = benchmark.run[test_floor]()
+    # print('floor f32 100x100')
+    # report_floor.print()
+    # fn test_ceil()capturing:
+    #     res = ceil[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_ceil = benchmark.run[test_ceil]()
+    # print('ceil f32 100x100')
+    # report_ceil.print()
+    # fn test_trunc()capturing:
+    #     res = trunc[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_trunc = benchmark.run[test_trunc]()
+    # print('trunc f32 100x100')
+    # report_trunc.print()
+    # fn test_round()capturing:
+    #     res = round[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_round = benchmark.run[test_round]()
+    # print('round f32 100x100')
+    # report_round.print()
+    # fn test_roundeven()capturing:
+    #     res = roundeven[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_roundeven = benchmark.run[test_roundeven]()
+    # print('roundeven f32 100x100')
+    # report_roundeven.print()
+    # fn test_round_half_down()capturing:
+    #     res = round_half_down[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_round_half_down = benchmark.run[test_round_half_down]()
+    # print('round_half_down f32 100x100')
+    # report_round_half_down.print()
+    # fn test_round_half_up()capturing:
+    #     res = round_half_up[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_round_half_up = benchmark.run[test_round_half_up]()
+    # print('round_half_up f32 100x100')
+    # report_round_half_up.print()
+    # fn test_rsqrt()capturing:
+    #     res = rsqrt[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_rsqrt = benchmark.run[test_rsqrt]()
+    # print('rsqrt f32 100x100')
+    # report_rsqrt.print()
+    # fn test_sqrt()capturing:
+    #     res = sqrt[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_sqrt = benchmark.run[test_sqrt]()
+    # print('sqrt f32 100x100')
+    # report_sqrt.print()
+    # fn test_exp2()capturing:
+    #     res = exp2[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_exp2 = benchmark.run[test_exp2]()
+    # print('exp2 f32 100x100')
+    # report_exp2.print()
+    # fn test_exp()capturing:
+    #     res = exp[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_exp = benchmark.run[test_exp]()
+    # print('exp f32 100x100')
+    # report_exp.print()
+    # fn test_log()capturing:
+    #     res = log[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_log = benchmark.run[test_log]()
+    # print('log f32 100x100')
+    # report_log.print()
+    # fn test_log2()capturing:
+    #     res = log2[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_log2 = benchmark.run[test_log2]()
+    # print('log2 f32 100x100')
+    # report_log2.print()
+    # # fn test_erf()capturing:
+    # #     res = erf[DType.float32,backend=backend](tens)
+    # #     keep(res.data())
+    # # var report_erf = benchmark.run[test_erf]()
+    # # print('erf f32 100x100')
+    # # report_erf.print()
+    # fn test_tanh()capturing:
+    #     res = tanh[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_tanh = benchmark.run[test_tanh]()
+    # print('tanh f32 100x100')
+    # report_tanh.print()
+    # fn test_reciprocal()capturing:
+    #     res = reciprocal[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_reciprocal = benchmark.run[test_reciprocal]()
+    # print('reciprocal f32 100x100')
+    # report_reciprocal.print()
+    # # fn test_identity()capturing:
+    # #     res = identity[DType.float32,backend=backend](tens)
+    # #     keep(res.data())
+    # # var report_identity = benchmark.run[test_identity]()
+    # # print('identity f32 100x100')
+    # # report_identity.print()
+    # fn test_acos()capturing:
+    #     res = acos[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_acos = benchmark.run[test_acos]()
+    # print('acos f32 100x100')
+    # report_acos.print()
+    # fn test_asin()capturing:
+    #     res = asin[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_asin = benchmark.run[test_asin]()
+    # print('asin f32 100x100')
+    # report_asin.print()
+    # fn test_atan()capturing:
+    #     res = atan[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_atan = benchmark.run[test_atan]()
+    # print('atan f32 100x100')
+    # report_atan.print()
+    # fn test_cos()capturing:
+    #     res = cos[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_cos = benchmark.run[test_cos]()
+    # print('cos f32 100x100')
+    # report_cos.print()
+    # fn test_sin()capturing:
+    #     res = sin[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_sin = benchmark.run[test_sin]()
+    # print('sin f32 100x100')
+    # report_sin.print()
+    # fn test_tan()capturing:
+    #     res = tan[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_tan = benchmark.run[test_tan]()
+    # print('tan f32 100x100')
+    # report_tan.print()
+    # fn test_acosh()capturing:
+    #     res = acosh[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_acosh = benchmark.run[test_acosh]()
+    # print('acosh f32 100x100')
+    # report_acosh.print()
+    # fn test_asinh()capturing:
+    #     res = asinh[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_asinh = benchmark.run[test_asinh]()
+    # print('asinh f32 100x100')
+    # report_asinh.print()
+    # fn test_atanh()capturing:
+    #     res = atanh[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_atanh = benchmark.run[test_atanh]()
+    # print('atanh f32 100x100')
+    # report_atanh.print()
+    # fn test_cosh()capturing:
+    #     res = cosh[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_cosh = benchmark.run[test_cosh]()
+    # print('cosh f32 100x100')
+    # report_cosh.print()
+    # fn test_sinh()capturing:
+    #     res = sinh[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_sinh = benchmark.run[test_sinh]()
+    # print('sinh f32 100x100')
+    # report_sinh.print()
+    # fn test_expm1()capturing:
+    #     res = expm1[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_expm1 = benchmark.run[test_expm1]()
+    # print('expm1 f32 100x100')
+    # report_expm1.print()
+    # fn test_log10()capturing:
+    #     res = log10[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_log10 = benchmark.run[test_log10]()
+    # print('log10 f32 100x100')
+    # report_log10.print()
+    # fn test_log1p()capturing:
+    #     res = log1p[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_log1p = benchmark.run[test_log1p]()
+    # print('log1p f32 100x100')
+    # report_log1p.print()
+    # fn test_cbrt()capturing:
+    #     res = cbrt[DType.float32,backend=backend](tens)
+    #     keep(res.data())
+    # var report_cbrt = benchmark.run[test_cbrt]()
+    # print('cbrt f32 100x100')
+    # report_cbrt.print()
     # fn test_erfc()capturing:
-    #     res = erfc[DType.float32](tens)
+    #     res = erfc[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_erfc = benchmark.run[test_erfc]()
     # print('erfc f32 100x100')
     # report_erfc.print()
     # fn test_lgamma()capturing:
-    #     res = lgamma[DType.float32](tens)
+    #     res = lgamma[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_lgamma = benchmark.run[test_lgamma]()
     # print('lgamma f32 100x100')
     # report_lgamma.print()
     # fn test_tgamma()capturing:
-    #     res = tgamma[DType.float32](tens)
+    #     res = tgamma[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_tgamma = benchmark.run[test_tgamma]()
     # print('tgamma f32 100x100')
     # report_tgamma.print()
     # fn test_nearbyint()capturing:
-    #     res = nearbyint[DType.float32](tens)
+    #     res = nearbyint[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_nearbyint = benchmark.run[test_nearbyint]()
     # print('nearbyint f32 100x100')
     # report_nearbyint.print()
     # fn test_rint()capturing:
-    #     res = rint[DType.float32](tens)
+    #     res = rint[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_rint = benchmark.run[test_rint]()
     # print('rint f32 100x100')
     # report_rint.print()
     # fn test_j0()capturing:
-    #     res = j0[DType.float32](tens)
+    #     res = j0[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_j0 = benchmark.run[test_j0]()
     # print('j0 f32 100x100')
     # report_j0.print()
     # fn test_j1()capturing:
-    #     res = j1[DType.float32](tens)
+    #     res = j1[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_j1 = benchmark.run[test_j1]()
     # print('j1 f32 100x100')
     # report_j1.print()
     # fn test_y0()capturing:
-    #     res = y0[DType.float32](tens)
+    #     res = y0[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_y0 = benchmark.run[test_y0]()
     # print('y0 f32 100x100')
     # report_y0.print()
     # fn test_y1()capturing:
-    #     res = y1[DType.float32](tens)
+    #     res = y1[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_y1 = benchmark.run[test_y1]()
     # print('y1 f32 100x100')
     # report_y1.print()
     # fn test_ulp()capturing:
-    #     res = ulp[DType.float32](tens)
+    #     res = ulp[DType.float32,backend=backend](tens)
     #     keep(res.data())
     # var report_ulp = benchmark.run[test_ulp]()
     # print('ulp f32 100x100')

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -1,6 +1,7 @@
 from .arithmetic import *
 from .trig import *
 from .cumulative_reduce import *
+# from  .comparison import *
 
 """
 A Mathematics and Algorithm Library for Mojo.

--- a/numojo/_math_funcs.mojo
+++ b/numojo/_math_funcs.mojo
@@ -4,178 +4,271 @@ Implements generic reusable functions for math
 from tensor import Tensor
 from testing import assert_raises
 
-
-fn _math_func_1_tensor_in_one_tensor_out[
-    dtype: DType,
-    func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-        type, simd_w
-    ],
-](tensor: Tensor[dtype]) -> Tensor[dtype]:
+trait Backend:
     """
-    Apply a SIMD function of one variable and one return to a tensor
-
-    Parameters:
-        dtype: The element type.
-        func: the SIMD function to to apply.
-
-    Args:
-        tensor: A tensor
-
-    Returns:
-        A a new tensor that is tensor with the function func applied.
+    A trait that defines backends for calculations in the rest of the library.
     """
-    var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-    alias opt_nelts = simdwidthof[dtype]()
-    for i in range(
-        0, opt_nelts * (tensor.num_elements() // opt_nelts), opt_nelts
-    ):
-        var simd_data = tensor.load[width=opt_nelts](i)
-        result_tensor.store[width=opt_nelts](
-            i, func[dtype, opt_nelts](simd_data)
-        )
 
-    if tensor.num_elements() % opt_nelts != 0:
+    fn __init__(inout self:Self):
+       pass
+
+    fn _math_func_1_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[dtype]:
+        """
+        Apply a SIMD function of one variable and one return to a tensor
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        ...
+
+
+    fn _math_func_2_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[type, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD function of two variable and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        ...
+
+    fn _math_func_compare_2_tensors[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[DType.bool, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+       ...
+
+    fn _math_func_is[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            DType.bool, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+        ...
+
+
+    fn _math_func_simd_int[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+        ...
+
+struct Vectorized(Backend):
+    """
+    Vectorized Backend Struct.
+
+    Defualt Numlt simdwidth.ojo computation backend takes advantage of SIMD.
+    Uses defualt.
+    """
+    
+    fn __init__(inout self:Self):
+       pass
+
+
+    
+    fn _math_func_1_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            type, simd_w
+        ],
+    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+        """
+        Apply a SIMD function of one variable and one return to a tensor
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
         for i in range(
-            opt_nelts * (tensor.num_elements() // opt_nelts),
-            tensor.num_elements(),
+            0, opt_nelts * (tensor.num_elements() // opt_nelts), opt_nelts
         ):
-            var simd_data = func[dtype, 1](tensor.load[width=1](i))
-            result_tensor.store[width=1](i, simd_data)
-    return result_tensor
-
-
-fn _math_func_2_tensor_in_one_tensor_out[
-    dtype: DType,
-    func: fn[type: DType, simd_w: Int] (
-        SIMD[type, simd_w], SIMD[type, simd_w]
-    ) -> SIMD[type, simd_w],
-](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
-    """
-    Apply a SIMD function of two variable and one return to a tensor
-
-    Constraints:
-        Both tensors must have the same shape
-
-    Parameters:
-        dtype: The element type.
-        func: the SIMD function to to apply.
-
-    Args:
-        tensor1: A tensor
-        tensor2: A tensor
-
-    Returns:
-        A a new tensor that is tensor with the function func applied.
-    """
-
-    if tensor1.shape() != tensor2.shape():
-        with assert_raises():
-            raise "Shape Mismatch error shapes must match for this function"
-    var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-    alias opt_nelts = simdwidthof[dtype]()
-    for i in range(
-        0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
-    ):
-        var simd_data1 = tensor1.load[width=opt_nelts](i)
-        var simd_data2 = tensor2.load[width=opt_nelts](i)
-        result_tensor.store[width=opt_nelts](
-            i, func[dtype, opt_nelts](simd_data1, simd_data2)
-        )
-
-    if tensor1.num_elements() % opt_nelts != 0:
-        for i in range(
-            opt_nelts * (tensor1.num_elements() // opt_nelts),
-            tensor1.num_elements(),
-        ):
-            var simd_data1 = tensor1.load[width=1](i)
-            var simd_data2 = tensor2.load[width=1](i)
-            result_tensor.store[width=1](
-                i, func[dtype, 1](simd_data1, simd_data2)
+            var simd_data = tensor.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data)
             )
-    return result_tensor
+
+        if tensor.num_elements() % opt_nelts != 0:
+            for i in range(
+                opt_nelts * (tensor.num_elements() // opt_nelts),
+                tensor.num_elements(),
+            ):
+                var simd_data = func[dtype, 1](tensor.load[width=1](i))
+                result_tensor.store[width=1](i, simd_data)
+        return result_tensor
 
 
-fn _math_func_compare_2_tensors[
-    dtype: DType,
-    func: fn[type: DType, simd_w: Int] (
-        SIMD[type, simd_w], SIMD[type, simd_w]
-    ) -> SIMD[DType.bool, simd_w],
-](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
-    if tensor1.shape() != tensor2.shape():
-        with assert_raises():
-            raise "Shape Mismatch error shapes must match for this function"
-    var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
-    alias opt_nelts = simdwidthof[dtype]()
-    for i in range(
-        0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
-    ):
-        var simd_data1 = tensor1.load[width=opt_nelts](i)
-        var simd_data2 = tensor2.load[width=opt_nelts](i)
-        result_tensor.store[width=opt_nelts](
-            i, func[dtype, opt_nelts](simd_data1, simd_data2)
-        )
+    fn _math_func_2_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[type, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD function of two variable and one return to a tensor
 
-    if tensor1.num_elements() % opt_nelts != 0:
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
         for i in range(
-            opt_nelts * (tensor1.num_elements() // opt_nelts),
-            tensor1.num_elements(),
+            0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
         ):
-            var simd_data1 = tensor1.load[width=1](i)
-            var simd_data2 = tensor2.load[width=1](i)
-            result_tensor.store[width=1](
-                i, func[dtype, 1](simd_data1, simd_data2)
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data1, simd_data2)
             )
-    return result_tensor
+
+        if tensor1.num_elements() % opt_nelts != 0:
+            for i in range(
+                opt_nelts * (tensor1.num_elements() // opt_nelts),
+                tensor1.num_elements(),
+            ):
+                var simd_data1 = tensor1.load[width=1](i)
+                var simd_data2 = tensor2.load[width=1](i)
+                result_tensor.store[width=1](
+                    i, func[dtype, 1](simd_data1, simd_data2)
+                )
+        return result_tensor
 
 
-fn _math_func_is[
-    dtype: DType,
-    func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-        DType.bool, simd_w
-    ],
-](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
-    alias opt_nelts = simdwidthof[dtype]()
-    for i in range(
-        0, opt_nelts * (tensor.num_elements() // opt_nelts), opt_nelts
-    ):
-        var simd_data = tensor.load[width=opt_nelts](i)
-        result_tensor.store[width=opt_nelts](
-            i, func[dtype, opt_nelts](simd_data)
-        )
-
-    if tensor.num_elements() % opt_nelts != 0:
+    fn _math_func_compare_2_tensors[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[DType.bool, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
         for i in range(
-            opt_nelts * (tensor.num_elements() // opt_nelts),
-            tensor.num_elements(),
+            0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
         ):
-            var simd_data = func[dtype, 1](tensor.load[width=1](i))
-            result_tensor.store[width=1](i, simd_data)
-    return result_tensor
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data1, simd_data2)
+            )
+
+        if tensor1.num_elements() % opt_nelts != 0:
+            for i in range(
+                opt_nelts * (tensor1.num_elements() // opt_nelts),
+                tensor1.num_elements(),
+            ):
+                var simd_data1 = tensor1.load[width=1](i)
+                var simd_data2 = tensor2.load[width=1](i)
+                result_tensor.store[width=1](
+                    i, func[dtype, 1](simd_data1, simd_data2)
+                )
+        return result_tensor
 
 
-fn _math_func_simd_int[
-    dtype: DType,
-    func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
-        type, simd_w
-    ],
-](tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
-    var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-    alias opt_nelts = simdwidthof[dtype]()
-    for i in range(
-        0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
-    ):
-        var simd_data1 = tensor1.load[width=opt_nelts](i)
-
-        result_tensor.store[width=opt_nelts](
-            i, func[dtype, opt_nelts](simd_data1, intval)
-        )
-
-    if tensor1.num_elements() % opt_nelts != 0:
+    fn _math_func_is[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            DType.bool, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
         for i in range(
-            opt_nelts * (tensor1.num_elements() // opt_nelts),
-            tensor1.num_elements(),
+            0, opt_nelts * (tensor.num_elements() // opt_nelts), opt_nelts
         ):
-            var simd_data1 = tensor1.load[width=1](i)
-            result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
-    return result_tensor
+            var simd_data = tensor.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data)
+            )
+
+        if tensor.num_elements() % opt_nelts != 0:
+            for i in range(
+                opt_nelts * (tensor.num_elements() // opt_nelts),
+                tensor.num_elements(),
+            ):
+                var simd_data = func[dtype, 1](tensor.load[width=1](i))
+                result_tensor.store[width=1](i, simd_data)
+        return result_tensor
+
+
+    fn _math_func_simd_int[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        for i in range(
+            0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
+        ):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data1, intval)
+            )
+
+        if tensor1.num_elements() % opt_nelts != 0:
+            for i in range(
+                opt_nelts * (tensor1.num_elements() // opt_nelts),
+                tensor1.num_elements(),
+            ):
+                var simd_data1 = tensor1.load[width=1](i)
+                result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
+        return result_tensor

--- a/numojo/_math_funcs.mojo
+++ b/numojo/_math_funcs.mojo
@@ -4,10 +4,16 @@ Implements generic reusable functions for math
 from tensor import Tensor
 from testing import assert_raises
 from algorithm.functional import parallelize, vectorize, num_physical_cores
+from .traits.backend import Backend
 
-trait Backend:
+struct Vectorized(Backend):
     """
-    A trait that defines backends for calculations in the rest of the library.
+    Vectorized Backend Struct.
+    Parameters
+        unroll_factor: factor by which loops are unrolled.
+
+    Defualt Numojo computation backend takes advantage of SIMD.
+    Uses defualt simdwidth.
     """
     
     fn __init__(inout self:Self):
@@ -33,13 +39,29 @@ trait Backend:
         Returns:
             A a new tensor that is tensor with the function func applied.
         """
-        pass
-    
+
+        if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            var simd_data3 = tensor3.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, SIMD.fma(simd_data1,simd_data2,simd_data3)
+            )
+
+        vectorize[closure, opt_nelts](tensor1.num_elements())
+        return result_tensor
+
     fn _math_func_fma[
         dtype: DType,
     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], simd: SIMD[dtype,1]) raises -> Tensor[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor.
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
 
         Constraints:
             Both tensors must have the same shape
@@ -48,21 +70,37 @@ trait Backend:
             dtype: The element type.
 
         Args:
-            tensor1: A tensor.
-            tensor2: A tensor.
+            tensor1: A tensor
+            tensor2: A tensor
             simd: A SIMD[dtype,1] value to be added
 
         Returns:
             A a new tensor that is tensor with the function func applied.
         """
-        pass
 
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            # var simd_data3 = tensor3.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, SIMD.fma(simd_data1,simd_data2,simd)
+            )
+
+        vectorize[closure, opt_nelts](tensor1.num_elements())
+        return result_tensor
+    
     fn _math_func_1_tensor_in_one_tensor_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
-    ](self:Self,tensor: Tensor[dtype]) -> Tensor[dtype]:
+    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
         """
         Apply a SIMD function of one variable and one return to a tensor
 
@@ -76,7 +114,19 @@ trait Backend:
         Returns:
             A a new tensor that is tensor with the function func applied.
         """
-        ...
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+       
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data)
+            )
+
+        vectorize[closure, opt_nelts](tensor.num_elements())
+        
+        return result_tensor
 
 
     fn _math_func_2_tensor_in_one_tensor_out[
@@ -103,7 +153,23 @@ trait Backend:
             A a new tensor that is tensor with the function func applied.
         """
 
-        ...
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data1, simd_data2)
+            )
+
+        vectorize[closure, opt_nelts](tensor1.num_elements())
+        return result_tensor
+
 
     fn _math_func_compare_2_tensors[
         dtype: DType,
@@ -111,7 +177,24 @@ trait Backend:
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[DType.bool, simd_w],
     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
-       ...
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+       
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data1, simd_data2)
+            )
+
+        vectorize[closure, opt_nelts](tensor1.num_elements())
+        return result_tensor
+        
+
 
     fn _math_func_is[
         dtype: DType,
@@ -119,7 +202,17 @@ trait Backend:
             DType.bool, simd_w
         ],
     ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-        ...
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data)
+            )
+
+        vectorize[closure, opt_nelts](tensor.num_elements())
+        return result_tensor
 
 
     fn _math_func_simd_int[
@@ -127,8 +220,755 @@ trait Backend:
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
             type, simd_w
         ],
-    ](self:Self,tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
-        ...
+    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data, intval)
+            )
+
+        vectorize[closure, opt_nelts](tensor.num_elements())
+        return result_tensor
+
+struct VectorizedUnroll[unroll_factor:Int=1](Backend):
+    """
+    Vectorized Backend Struct.
+    Parameters
+        unroll_factor: factor by which loops are unrolled.
+
+    Defualt Numojo computation backend takes advantage of SIMD.
+    Uses defualt simdwidth.
+    """
+    
+    fn __init__(inout self:Self):
+       pass
+
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+            tensor3: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            var simd_data3 = tensor3.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, SIMD.fma(simd_data1,simd_data2,simd_data3)
+            )
+
+        vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
+        return result_tensor
+    
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], simd: SIMD[dtype,1]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor.
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor.
+            tensor2: A tensor.
+            simd: A SIMD[dtype,1] value to be added
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            
+            result_tensor.store[width=opt_nelts](
+                i, SIMD.fma(simd_data1,simd_data2,simd)
+            )
+
+        vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
+        return result_tensor
+
+    
+    fn _math_func_1_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            type, simd_w
+        ],
+    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+        """
+        Apply a SIMD function of one variable and one return to a tensor
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+       
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data)
+            )
+
+        vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor.num_elements())
+        
+        return result_tensor
+
+
+    fn _math_func_2_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[type, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD function of two variable and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data1, simd_data2)
+            )
+
+        vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
+        return result_tensor
+
+
+    fn _math_func_compare_2_tensors[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[DType.bool, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+       
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data1, simd_data2)
+            )
+
+        vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
+        return result_tensor
+        
+
+
+    fn _math_func_is[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            DType.bool, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data)
+            )
+
+        vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor.num_elements())
+        return result_tensor
+
+
+    fn _math_func_simd_int[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data, intval)
+            )
+
+        vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor.num_elements())
+        return result_tensor
+
+struct Parallelized(Backend):
+    """
+    Parrallelized Backend Struct.
+
+    Currently an order of magnitude slower than Vectorized for most functions.
+    No idea why, Not Reccomened for use at this Time.
+    """
+    
+    fn __init__(inout self:Self):
+       pass
+
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+            tensor3: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = 1
+        var num_cores: Int = num_physical_cores()
+        var comps_per_core: Int = tensor1.num_elements()//num_cores
+        var comps_remainder: Int = tensor1.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
+                var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
+                var simd_data3 = tensor3.load[width=opt_nelts](i+comps_per_core*j)
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, SIMD.fma(simd_data1,simd_data2,simd_data3)
+                )
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        # @parameter
+        # fn remainder_closure[simdwidth: Int](i: Int):
+        #     var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
+        #     var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
+        #     var simd_data3 = tensor3.load[width=opt_nelts](i+remainder_offset)
+        #     result_tensor.store[width=opt_nelts](
+        #         i+remainder_offset, SIMD.fma(simd_data1,simd_data2,simd_data3)
+        #     )
+        # vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], simd: SIMD[dtype,1]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor.
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor.
+            tensor2: A tensor.
+            simd: A SIMD[dtype,1] value to be added
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = 1
+        var num_cores: Int = num_physical_cores()
+        var comps_per_core: Int = tensor1.num_elements()//num_cores
+        var comps_remainder: Int = tensor1.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
+                var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
+                
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, SIMD.fma(simd_data1,simd_data2,simd)
+                )
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        # @parameter
+        # fn remainder_closure[simdwidth: Int](i: Int):
+        #     var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
+        #     var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
+        #     result_tensor.store[width=opt_nelts](
+        #         i+remainder_offset, SIMD.fma(simd_data1,simd_data2,simd)
+        #     )
+        # vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+    fn _math_func_1_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            type, simd_w
+        ],
+    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+        """
+        Apply a SIMD function of one variable and one return to a tensor
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = 1
+        var num_cores: Int = num_physical_cores()
+        var comps_per_core: Int = tensor.num_elements()//num_cores
+        var comps_remainder: Int = tensor.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
+                )
+
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        # @parameter
+        # fn remainder_closure[simdwidth: Int](i: Int):
+        #     var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
+        #     result_tensor.store[width=opt_nelts](
+        #         i+remainder_offset, func[dtype, opt_nelts](simd_data)
+        #     )
+        # vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+
+
+    fn _math_func_2_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[type, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD function of two variable and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = 1
+        var num_cores: Int = num_physical_cores()
+        var comps_per_core: Int = tensor1.num_elements()//num_cores
+        var comps_remainder: Int = tensor1.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
+                var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
+                )
+
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        # @parameter
+        # fn remainder_closure[simdwidth: Int](i: Int):
+        #     var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
+        #     var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
+        #     result_tensor.store[width=opt_nelts](
+        #         i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
+        #     )
+        # vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+
+
+    fn _math_func_compare_2_tensors[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[DType.bool, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+        alias opt_nelts = 1
+        var num_cores: Int = num_physical_cores()
+        var comps_per_core: Int = tensor1.num_elements()//num_cores
+        var comps_remainder: Int = tensor1.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
+                var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
+                )
+
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        # @parameter
+        # fn remainder_closure[simdwidth: Int](i: Int):
+        #     var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
+        #     var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
+        #     result_tensor.store[width=opt_nelts](
+        #         i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
+        #     )
+        # vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+        
+
+
+    fn _math_func_is[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            DType.bool, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+        alias opt_nelts = 1
+        var num_cores: Int =  num_physical_cores()
+        var comps_per_core: Int = tensor.num_elements()//num_cores
+        var comps_remainder: Int = tensor.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
+                )
+
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        # @parameter
+        # fn remainder_closure[simdwidth: Int](i: Int):
+        #     var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
+        #     result_tensor.store[width=opt_nelts](
+        #         i+remainder_offset, func[dtype, opt_nelts](simd_data)
+        #     )
+        # vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+
+
+    fn _math_func_simd_int[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data, intval)
+            )
+
+        vectorize[closure, opt_nelts](tensor.num_elements())
+        return result_tensor
+
+struct Naive(Backend):
+    """
+    Naive Backend Struct.
+
+    Just loops for SIMD[Dtype, 1] equations
+    """
+    
+    fn __init__(inout self:Self):
+       pass
+
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+            tensor3: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+       
+        for i in range(tensor1.num_elements()):
+            var simd_data1 = tensor1.load[width=1](i)
+            var simd_data2 = tensor2.load[width=1](i)
+            var simd_data3 = tensor3.load[width=1](i)
+            result_tensor.store[width=1](
+                i, SIMD.fma(simd_data1, simd_data2, simd_data3)
+            )
+        return result_tensor
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], simd: SIMD[dtype,1]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor.
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor.
+            tensor2: A tensor.
+            simd: A SIMD[dtype,1] value to be added
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+       
+        for i in range(tensor1.num_elements()):
+            var simd_data1 = tensor1.load[width=1](i)
+            var simd_data2 = tensor2.load[width=1](i)
+            
+            result_tensor.store[width=1](
+                i, SIMD.fma(simd_data1, simd_data2, simd)
+            )
+        return result_tensor
+    
+    fn _math_func_1_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            type, simd_w
+        ],
+    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+        """
+        Apply a SIMD function of one variable and one return to a tensor
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        
+        for i in range(
+            tensor.num_elements()
+        ):
+            var simd_data = func[dtype, 1](tensor.load[width=1](i))
+            result_tensor.store[width=1](i, simd_data)
+        return result_tensor
+
+
+    fn _math_func_2_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[type, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD function of two variable and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        
+        for i in range(tensor1.num_elements()):
+            var simd_data1 = tensor1.load[width=1](i)
+            var simd_data2 = tensor2.load[width=1](i)
+            result_tensor.store[width=1](
+                i, func[dtype, 1](simd_data1, simd_data2)
+            )
+        return result_tensor
+
+
+    fn _math_func_compare_2_tensors[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[DType.bool, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+        
+        for i in range(tensor1.num_elements()):
+            var simd_data1 = tensor1.load[width=1](i)
+            var simd_data2 = tensor2.load[width=1](i)
+            result_tensor.store[width=1](
+                i, func[dtype, 1](simd_data1, simd_data2)
+            )
+        return result_tensor
+
+
+    fn _math_func_is[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            DType.bool, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+        
+
+        for i in range(tensor.num_elements()):
+            var simd_data = func[dtype, 1](tensor.load[width=1](i))
+            result_tensor.store[width=1](i, simd_data)
+        return result_tensor
+
+
+    fn _math_func_simd_int[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        
+        for i in range(tensor.num_elements()):
+            var simd_data1 = tensor.load[width=1](i)
+            result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
+        return result_tensor
 
 # struct VectorizedVerbose(Backend):
 #     """
@@ -364,847 +1204,4 @@ trait Backend:
 #             ):
 #                 var simd_data1 = tensor1.load[width=1](i)
 #                 result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
-#         return result_tensor
-
-
-struct Vectorized(Backend):
-    """
-    Vectorized Backend Struct.
-    Parameters
-        unroll_factor: factor by which loops are unrolled.
-
-    Defualt Numojo computation backend takes advantage of SIMD.
-    Uses defualt simdwidth.
-    """
-    
-    fn __init__(inout self:Self):
-       pass
-
-    fn _math_func_fma[
-        dtype: DType,
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
-        """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
-
-        Constraints:
-            Both tensors must have the same shape
-
-        Parameters:
-            dtype: The element type.
-
-        Args:
-            tensor1: A tensor
-            tensor2: A tensor
-            tensor3: A tensor
-
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
-
-        if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        @parameter
-        fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = tensor1.load[width=opt_nelts](i)
-            var simd_data2 = tensor2.load[width=opt_nelts](i)
-            var simd_data3 = tensor3.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, SIMD.fma(simd_data1,simd_data2,simd_data3)
-            )
-
-        vectorize[closure, opt_nelts](tensor1.num_elements())
-        return result_tensor
-
-    fn _math_func_fma[
-        dtype: DType,
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], simd: SIMD[dtype,1]) raises -> Tensor[dtype]:
-        """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
-
-        Constraints:
-            Both tensors must have the same shape
-
-        Parameters:
-            dtype: The element type.
-
-        Args:
-            tensor1: A tensor
-            tensor2: A tensor
-            simd: A SIMD[dtype,1] value to be added
-
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
-
-        if tensor1.shape() != tensor2.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        @parameter
-        fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = tensor1.load[width=opt_nelts](i)
-            var simd_data2 = tensor2.load[width=opt_nelts](i)
-            # var simd_data3 = tensor3.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, SIMD.fma(simd_data1,simd_data2,simd)
-            )
-
-        vectorize[closure, opt_nelts](tensor1.num_elements())
-        return result_tensor
-    
-    fn _math_func_1_tensor_in_one_tensor_out[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-            type, simd_w
-        ],
-    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
-        """
-        Apply a SIMD function of one variable and one return to a tensor
-
-        Parameters:
-            dtype: The element type.
-            func: the SIMD function to to apply.
-
-        Args:
-            tensor: A tensor
-
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-       
-        @parameter
-        fn closure[simdwidth: Int](i: Int):
-            var simd_data = tensor.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data)
-            )
-
-        vectorize[closure, opt_nelts](tensor.num_elements())
-        
-        return result_tensor
-
-
-    fn _math_func_2_tensor_in_one_tensor_out[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
-        """
-        Apply a SIMD function of two variable and one return to a tensor
-
-        Constraints:
-            Both tensors must have the same shape
-
-        Parameters:
-            dtype: The element type.
-            func: the SIMD function to to apply.
-
-        Args:
-            tensor1: A tensor
-            tensor2: A tensor
-
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
-
-        if tensor1.shape() != tensor2.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        
-        @parameter
-        fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = tensor1.load[width=opt_nelts](i)
-            var simd_data2 = tensor2.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data1, simd_data2)
-            )
-
-        vectorize[closure, opt_nelts](tensor1.num_elements())
-        return result_tensor
-
-
-    fn _math_func_compare_2_tensors[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
-        if tensor1.shape() != tensor2.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-       
-        @parameter
-        fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = tensor1.load[width=opt_nelts](i)
-            var simd_data2 = tensor2.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data1, simd_data2)
-            )
-
-        vectorize[closure, opt_nelts](tensor1.num_elements())
-        return result_tensor
-        
-
-
-    fn _math_func_is[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-            DType.bool, simd_w
-        ],
-    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        @parameter
-        fn closure[simdwidth: Int](i: Int):
-            var simd_data = tensor.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data)
-            )
-
-        vectorize[closure, opt_nelts](tensor.num_elements())
-        return result_tensor
-
-
-    fn _math_func_simd_int[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
-            type, simd_w
-        ],
-    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
-
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        
-        @parameter
-        fn closure[simdwidth: Int](i: Int):
-            var simd_data = tensor.load[width=opt_nelts](i)
-
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data, intval)
-            )
-
-        vectorize[closure, opt_nelts](tensor.num_elements())
-        return result_tensor
-
-# struct VectorizedUnroll[unroll_factor:Int=1](Backend):
-#     """
-#     Vectorized Backend Struct.
-#     Parameters
-#         unroll_factor: factor by which loops are unrolled.
-
-#     Defualt Numojo computation backend takes advantage of SIMD.
-#     Uses defualt simdwidth.
-#     """
-    
-#     fn __init__(inout self:Self):
-#        pass
-
-#     fn _math_func_fma[
-#         dtype: DType,
-#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
-#         """
-#         Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
-
-#         Constraints:
-#             Both tensors must have the same shape
-
-#         Parameters:
-#             dtype: The element type.
-
-#         Args:
-#             tensor1: A tensor
-#             tensor2: A tensor
-#             tensor3: A tensor
-
-#         Returns:
-#             A a new tensor that is tensor with the function func applied.
-#         """
-
-#         if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
-#             with assert_raises():
-#                 raise "Shape Mismatch error shapes must match for this function"
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-#         @parameter
-#         fn closure[simdwidth: Int](i: Int):
-#             var simd_data1 = tensor1.load[width=opt_nelts](i)
-#             var simd_data2 = tensor2.load[width=opt_nelts](i)
-#             var simd_data3 = tensor3.load[width=opt_nelts](i)
-#             result_tensor.store[width=opt_nelts](
-#                 i, SIMD.fma(simd_data1,simd_data2,simd_data3)
-#             )
-
-#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
-#         return result_tensor
-    
-#     fn _math_func_1_tensor_in_one_tensor_out[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-#             type, simd_w
-#         ],
-#     ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
-#         """
-#         Apply a SIMD function of one variable and one return to a tensor
-
-#         Parameters:
-#             dtype: The element type.
-#             func: the SIMD function to to apply.
-
-#         Args:
-#             tensor: A tensor
-
-#         Returns:
-#             A a new tensor that is tensor with the function func applied.
-#         """
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-       
-#         @parameter
-#         fn closure[simdwidth: Int](i: Int):
-#             var simd_data = tensor.load[width=opt_nelts](i)
-#             result_tensor.store[width=opt_nelts](
-#                 i, func[dtype, opt_nelts](simd_data)
-#             )
-
-#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor.num_elements())
-        
-#         return result_tensor
-
-
-#     fn _math_func_2_tensor_in_one_tensor_out[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (
-#             SIMD[type, simd_w], SIMD[type, simd_w]
-#         ) -> SIMD[type, simd_w],
-#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
-#         """
-#         Apply a SIMD function of two variable and one return to a tensor
-
-#         Constraints:
-#             Both tensors must have the same shape
-
-#         Parameters:
-#             dtype: The element type.
-#             func: the SIMD function to to apply.
-
-#         Args:
-#             tensor1: A tensor
-#             tensor2: A tensor
-
-#         Returns:
-#             A a new tensor that is tensor with the function func applied.
-#         """
-
-#         if tensor1.shape() != tensor2.shape():
-#             with assert_raises():
-#                 raise "Shape Mismatch error shapes must match for this function"
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-        
-#         @parameter
-#         fn closure[simdwidth: Int](i: Int):
-#             var simd_data1 = tensor1.load[width=opt_nelts](i)
-#             var simd_data2 = tensor2.load[width=opt_nelts](i)
-#             result_tensor.store[width=opt_nelts](
-#                 i, func[dtype, opt_nelts](simd_data1, simd_data2)
-#             )
-
-#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
-#         return result_tensor
-
-
-#     fn _math_func_compare_2_tensors[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (
-#             SIMD[type, simd_w], SIMD[type, simd_w]
-#         ) -> SIMD[DType.bool, simd_w],
-#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
-#         if tensor1.shape() != tensor2.shape():
-#             with assert_raises():
-#                 raise "Shape Mismatch error shapes must match for this function"
-#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-       
-#         @parameter
-#         fn closure[simdwidth: Int](i: Int):
-#             var simd_data1 = tensor1.load[width=opt_nelts](i)
-#             var simd_data2 = tensor2.load[width=opt_nelts](i)
-#             result_tensor.store[width=opt_nelts](
-#                 i, func[dtype, opt_nelts](simd_data1, simd_data2)
-#             )
-
-#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
-#         return result_tensor
-        
-
-
-#     fn _math_func_is[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-#             DType.bool, simd_w
-#         ],
-#     ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-#         @parameter
-#         fn closure[simdwidth: Int](i: Int):
-#             var simd_data = tensor.load[width=opt_nelts](i)
-#             result_tensor.store[width=opt_nelts](
-#                 i, func[dtype, opt_nelts](simd_data)
-#             )
-
-#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor.num_elements())
-#         return result_tensor
-
-
-#     fn _math_func_simd_int[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
-#             type, simd_w
-#         ],
-#     ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
-
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-        
-#         @parameter
-#         fn closure[simdwidth: Int](i: Int):
-#             var simd_data = tensor.load[width=opt_nelts](i)
-
-#             result_tensor.store[width=opt_nelts](
-#                 i, func[dtype, opt_nelts](simd_data, intval)
-#             )
-
-#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor.num_elements())
-#         return result_tensor
-
-# struct VectorizedParallelized(Backend):
-#     """
-#     Vectorized and parrallelized Backend Struct.
-
-#     Currently an order of magnitude slower than Vectorized for most functions.
-#     No idea why, Not Reccomened for use at this Time.
-#     """
-    
-#     fn __init__(inout self:Self):
-#        pass
-
-#     fn _math_func_fma[
-#         dtype: DType,
-#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
-#         """
-#         Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
-
-#         Constraints:
-#             Both tensors must have the same shape
-
-#         Parameters:
-#             dtype: The element type.
-
-#         Args:
-#             tensor1: A tensor
-#             tensor2: A tensor
-#             tensor3: A tensor
-
-#         Returns:
-#             A a new tensor that is tensor with the function func applied.
-#         """
-
-#         if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
-#             with assert_raises():
-#                 raise "Shape Mismatch error shapes must match for this function"
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-#         var num_cores: Int = num_physical_cores()
-#         var comps_per_core: Int = tensor1.num_elements()//num_cores
-#         var comps_remainder: Int = tensor1.num_elements()%num_cores
-#         var remainder_offset: Int = num_cores * comps_per_core
-#         @parameter
-#         fn par_closure(j:Int):
-#             @parameter
-#             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
-#                 var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
-#                 var simd_data3 = tensor3.load[width=opt_nelts](i+comps_per_core*j)
-#                 result_tensor.store[width=opt_nelts](
-#                     i+comps_per_core*j, SIMD.fma(simd_data1,simd_data2,simd_data3)
-#                 )
-#             vectorize[closure, opt_nelts](comps_per_core)
-#         parallelize[par_closure]()
-#         @parameter
-#         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
-#             var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
-#             var simd_data3 = tensor3.load[width=opt_nelts](i+remainder_offset)
-#             result_tensor.store[width=opt_nelts](
-#                 i+remainder_offset, SIMD.fma(simd_data1,simd_data2,simd_data3)
-#             )
-#         vectorize[remainder_closure, opt_nelts](comps_remainder)
-#         return result_tensor
-
-#     fn _math_func_1_tensor_in_one_tensor_out[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-#             type, simd_w
-#         ],
-#     ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
-#         """
-#         Apply a SIMD function of one variable and one return to a tensor
-
-#         Parameters:
-#             dtype: The element type.
-#             func: the SIMD function to to apply.
-
-#         Args:
-#             tensor: A tensor
-
-#         Returns:
-#             A a new tensor that is tensor with the function func applied.
-#         """
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-#         var num_cores: Int = num_physical_cores()
-#         var comps_per_core: Int = tensor.num_elements()//num_cores
-#         var comps_remainder: Int = tensor.num_elements()%num_cores
-#         var remainder_offset: Int = num_cores * comps_per_core
-#         @parameter
-#         fn par_closure(j:Int):
-#             @parameter
-#             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
-#                 result_tensor.store[width=opt_nelts](
-#                     i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
-#                 )
-
-#             vectorize[closure, opt_nelts](comps_per_core)
-#         parallelize[par_closure]()
-#         @parameter
-#         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
-#             result_tensor.store[width=opt_nelts](
-#                 i+remainder_offset, func[dtype, opt_nelts](simd_data)
-#             )
-#         vectorize[remainder_closure, opt_nelts](comps_remainder)
-#         return result_tensor
-
-
-#     fn _math_func_2_tensor_in_one_tensor_out[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (
-#             SIMD[type, simd_w], SIMD[type, simd_w]
-#         ) -> SIMD[type, simd_w],
-#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
-#         """
-#         Apply a SIMD function of two variable and one return to a tensor
-
-#         Constraints:
-#             Both tensors must have the same shape
-
-#         Parameters:
-#             dtype: The element type.
-#             func: the SIMD function to to apply.
-
-#         Args:
-#             tensor1: A tensor
-#             tensor2: A tensor
-
-#         Returns:
-#             A a new tensor that is tensor with the function func applied.
-#         """
-
-#         if tensor1.shape() != tensor2.shape():
-#             with assert_raises():
-#                 raise "Shape Mismatch error shapes must match for this function"
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-#         var num_cores: Int = num_physical_cores()
-#         var comps_per_core: Int = tensor1.num_elements()//num_cores
-#         var comps_remainder: Int = tensor1.num_elements()%num_cores
-#         var remainder_offset: Int = num_cores * comps_per_core
-#         @parameter
-#         fn par_closure(j:Int):
-#             @parameter
-#             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
-#                 var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
-#                 result_tensor.store[width=opt_nelts](
-#                     i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
-#                 )
-
-#             vectorize[closure, opt_nelts](comps_per_core)
-#         parallelize[par_closure]()
-#         @parameter
-#         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
-#             var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
-#             result_tensor.store[width=opt_nelts](
-#                 i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
-#             )
-#         vectorize[remainder_closure, opt_nelts](comps_remainder)
-#         return result_tensor
-
-
-#     fn _math_func_compare_2_tensors[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (
-#             SIMD[type, simd_w], SIMD[type, simd_w]
-#         ) -> SIMD[DType.bool, simd_w],
-#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
-#         if tensor1.shape() != tensor2.shape():
-#             with assert_raises():
-#                 raise "Shape Mismatch error shapes must match for this function"
-#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-#         var num_cores: Int = num_physical_cores()
-#         var comps_per_core: Int = tensor1.num_elements()//num_cores
-#         var comps_remainder: Int = tensor1.num_elements()%num_cores
-#         var remainder_offset: Int = num_cores * comps_per_core
-#         @parameter
-#         fn par_closure(j:Int):
-#             @parameter
-#             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
-#                 var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
-#                 result_tensor.store[width=opt_nelts](
-#                     i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
-#                 )
-
-#             vectorize[closure, opt_nelts](comps_per_core)
-#         parallelize[par_closure]()
-#         @parameter
-#         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
-#             var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
-#             result_tensor.store[width=opt_nelts](
-#                 i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
-#             )
-#         vectorize[remainder_closure, opt_nelts](comps_remainder)
-#         return result_tensor
-        
-
-
-#     fn _math_func_is[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-#             DType.bool, simd_w
-#         ],
-#     ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-#         var num_cores: Int =  num_physical_cores()
-#         var comps_per_core: Int = tensor.num_elements()//num_cores
-#         var comps_remainder: Int = tensor.num_elements()%num_cores
-#         var remainder_offset: Int = num_cores * comps_per_core
-#         @parameter
-#         fn par_closure(j:Int):
-#             @parameter
-#             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
-#                 result_tensor.store[width=opt_nelts](
-#                     i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
-#                 )
-
-#             vectorize[closure, opt_nelts](comps_per_core)
-#         parallelize[par_closure]()
-#         @parameter
-#         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
-#             result_tensor.store[width=opt_nelts](
-#                 i+remainder_offset, func[dtype, opt_nelts](simd_data)
-#             )
-#         vectorize[remainder_closure, opt_nelts](comps_remainder)
-#         return result_tensor
-
-
-#     fn _math_func_simd_int[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
-#             type, simd_w
-#         ],
-#     ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
-
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-        
-#         @parameter
-#         fn closure[simdwidth: Int](i: Int):
-#             var simd_data = tensor.load[width=opt_nelts](i)
-
-#             result_tensor.store[width=opt_nelts](
-#                 i, func[dtype, opt_nelts](simd_data, intval)
-#             )
-
-#         vectorize[closure, opt_nelts](tensor.num_elements())
-#         return result_tensor
-
-# struct Naive(Backend):
-#     """
-#     Naive Backend Struct.
-
-#     Just loops for SIMD[Dtype, 1] equations
-#     """
-    
-#     fn __init__(inout self:Self):
-#        pass
-
-#     fn _math_func_fma[
-#         dtype: DType,
-#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
-#         """
-#         Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
-
-#         Constraints:
-#             Both tensors must have the same shape
-
-#         Parameters:
-#             dtype: The element type.
-
-#         Args:
-#             tensor1: A tensor
-#             tensor2: A tensor
-#             tensor3: A tensor
-
-#         Returns:
-#             A a new tensor that is tensor with the function func applied.
-#         """
-
-#         if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
-#             with assert_raises():
-#                 raise "Shape Mismatch error shapes must match for this function"
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-#         alias opt_nelts = simdwidthof[dtype]()
-       
-#         for i in range(tensor1.num_elements()):
-#             var simd_data1 = tensor1.load[width=1](i)
-#             var simd_data2 = tensor2.load[width=1](i)
-#             var simd_data3 = tensor3.load[width=1](i)
-#             result_tensor.store[width=1](
-#                 i, SIMD.fma(simd_data1, simd_data2, simd_data3)
-#             )
-#         return result_tensor
-    
-#     fn _math_func_1_tensor_in_one_tensor_out[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-#             type, simd_w
-#         ],
-#     ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
-#         """
-#         Apply a SIMD function of one variable and one return to a tensor
-
-#         Parameters:
-#             dtype: The element type.
-#             func: the SIMD function to to apply.
-
-#         Args:
-#             tensor: A tensor
-
-#         Returns:
-#             A a new tensor that is tensor with the function func applied.
-#         """
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-        
-#         for i in range(
-#             tensor.num_elements()
-#         ):
-#             var simd_data = func[dtype, 1](tensor.load[width=1](i))
-#             result_tensor.store[width=1](i, simd_data)
-#         return result_tensor
-
-
-#     fn _math_func_2_tensor_in_one_tensor_out[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (
-#             SIMD[type, simd_w], SIMD[type, simd_w]
-#         ) -> SIMD[type, simd_w],
-#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
-#         """
-#         Apply a SIMD function of two variable and one return to a tensor
-
-#         Constraints:
-#             Both tensors must have the same shape
-
-#         Parameters:
-#             dtype: The element type.
-#             func: the SIMD function to to apply.
-
-#         Args:
-#             tensor1: A tensor
-#             tensor2: A tensor
-
-#         Returns:
-#             A a new tensor that is tensor with the function func applied.
-#         """
-
-#         if tensor1.shape() != tensor2.shape():
-#             with assert_raises():
-#                 raise "Shape Mismatch error shapes must match for this function"
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-        
-#         for i in range(tensor1.num_elements()):
-#             var simd_data1 = tensor1.load[width=1](i)
-#             var simd_data2 = tensor2.load[width=1](i)
-#             result_tensor.store[width=1](
-#                 i, func[dtype, 1](simd_data1, simd_data2)
-#             )
-#         return result_tensor
-
-
-#     fn _math_func_compare_2_tensors[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (
-#             SIMD[type, simd_w], SIMD[type, simd_w]
-#         ) -> SIMD[DType.bool, simd_w],
-#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
-#         if tensor1.shape() != tensor2.shape():
-#             with assert_raises():
-#                 raise "Shape Mismatch error shapes must match for this function"
-#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
-        
-#         for i in range(tensor1.num_elements()):
-#             var simd_data1 = tensor1.load[width=1](i)
-#             var simd_data2 = tensor2.load[width=1](i)
-#             result_tensor.store[width=1](
-#                 i, func[dtype, 1](simd_data1, simd_data2)
-#             )
-#         return result_tensor
-
-
-#     fn _math_func_is[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-#             DType.bool, simd_w
-#         ],
-#     ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
-        
-
-#         for i in range(tensor.num_elements()):
-#             var simd_data = func[dtype, 1](tensor.load[width=1](i))
-#             result_tensor.store[width=1](i, simd_data)
-#         return result_tensor
-
-
-#     fn _math_func_simd_int[
-#         dtype: DType,
-#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
-#             type, simd_w
-#         ],
-#     ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
-#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-        
-#         for i in range(tensor.num_elements()):
-#             var simd_data1 = tensor.load[width=1](i)
-#             result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
 #         return result_tensor

--- a/numojo/_math_funcs.mojo
+++ b/numojo/_math_funcs.mojo
@@ -89,8 +89,8 @@ struct Vectorized(Backend):
     """
     Vectorized Backend Struct.
 
-    Defualt Numlt simdwidth.ojo computation backend takes advantage of SIMD.
-    Uses defualt.
+    Defualt Numojo computation backend takes advantage of SIMD.
+    Uses defualt simdwidth.
     """
     
     fn __init__(inout self:Self):
@@ -271,4 +271,131 @@ struct Vectorized(Backend):
             ):
                 var simd_data1 = tensor1.load[width=1](i)
                 result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
+        return result_tensor
+
+struct Naive(Backend):
+    """
+    Naive Backend Struct.
+
+    Just loops for SIMD[Dtype, 1] equations
+    """
+    
+    fn __init__(inout self:Self):
+       pass
+
+
+    
+    fn _math_func_1_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            type, simd_w
+        ],
+    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+        """
+        Apply a SIMD function of one variable and one return to a tensor
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        
+        for i in range(
+            tensor.num_elements()
+        ):
+            var simd_data = func[dtype, 1](tensor.load[width=1](i))
+            result_tensor.store[width=1](i, simd_data)
+        return result_tensor
+
+
+    fn _math_func_2_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[type, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD function of two variable and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        
+        for i in range(tensor1.num_elements()):
+            var simd_data1 = tensor1.load[width=1](i)
+            var simd_data2 = tensor2.load[width=1](i)
+            result_tensor.store[width=1](
+                i, func[dtype, 1](simd_data1, simd_data2)
+            )
+        return result_tensor
+
+
+    fn _math_func_compare_2_tensors[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[DType.bool, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+        
+        for i in range(tensor1.num_elements()):
+            var simd_data1 = tensor1.load[width=1](i)
+            var simd_data2 = tensor2.load[width=1](i)
+            result_tensor.store[width=1](
+                i, func[dtype, 1](simd_data1, simd_data2)
+            )
+        return result_tensor
+
+
+    fn _math_func_is[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            DType.bool, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+        
+
+        for i in range(tensor.num_elements()):
+            var simd_data = func[dtype, 1](tensor.load[width=1](i))
+            result_tensor.store[width=1](i, simd_data)
+        return result_tensor
+
+
+    fn _math_func_simd_int[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        
+        for i in range(tensor.num_elements()):
+            var simd_data1 = tensor.load[width=1](i)
+            result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
         return result_tensor

--- a/numojo/_math_funcs.mojo
+++ b/numojo/_math_funcs.mojo
@@ -3,6 +3,7 @@ Implements generic reusable functions for math
 """
 from tensor import Tensor
 from testing import assert_raises
+from algorithm.functional import parallelize, vectorize, num_physical_cores
 
 trait Backend:
     """
@@ -85,7 +86,7 @@ trait Backend:
     ](self:Self,tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
         ...
 
-struct Vectorized(Backend):
+struct VectorizedVerbose(Backend):
     """
     Vectorized Backend Struct.
 
@@ -271,6 +272,370 @@ struct Vectorized(Backend):
             ):
                 var simd_data1 = tensor1.load[width=1](i)
                 result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
+        return result_tensor
+
+
+struct _Vectorized(Backend):
+    """
+    Vectorized Backend Struct.
+
+    Defualt Numojo computation backend takes advantage of SIMD.
+    Uses defualt simdwidth.
+    """
+    
+    fn __init__(inout self:Self):
+       pass
+
+
+    
+    fn _math_func_1_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            type, simd_w
+        ],
+    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+        """
+        Apply a SIMD function of one variable and one return to a tensor
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+       
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data)
+            )
+
+        vectorize[closure, opt_nelts](tensor.num_elements())
+        
+        return result_tensor
+
+
+    fn _math_func_2_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[type, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD function of two variable and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data1, simd_data2)
+            )
+
+        vectorize[closure, opt_nelts](tensor1.num_elements())
+        return result_tensor
+
+
+    fn _math_func_compare_2_tensors[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[DType.bool, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+       
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data1, simd_data2)
+            )
+
+        vectorize[closure, opt_nelts](tensor1.num_elements())
+        return result_tensor
+        
+
+
+    fn _math_func_is[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            DType.bool, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data)
+            )
+
+        vectorize[closure, opt_nelts](tensor.num_elements())
+        return result_tensor
+
+
+    fn _math_func_simd_int[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data, intval)
+            )
+
+        vectorize[closure, opt_nelts](tensor.num_elements())
+        return result_tensor
+
+
+struct Vectorized(Backend):#Parallelized(Backend):
+    """
+    Vectorized Backend Struct.
+
+    Defualt Numojo computation backend takes advantage of SIMD.
+    Uses defualt simdwidth.
+    """
+    
+    fn __init__(inout self:Self):
+       pass
+
+
+    
+    fn _math_func_1_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            type, simd_w
+        ],
+    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+        """
+        Apply a SIMD function of one variable and one return to a tensor
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        var num_cores: Int = num_physical_cores()
+        var comps_per_core: Int = tensor.num_elements()//num_cores
+        var comps_remainder: Int = tensor.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
+                )
+
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        @parameter
+        fn remainder_closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
+            result_tensor.store[width=opt_nelts](
+                i+remainder_offset, func[dtype, opt_nelts](simd_data)
+            )
+        vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+
+
+    fn _math_func_2_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[type, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD function of two variable and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        var num_cores: Int = num_physical_cores()
+        var comps_per_core: Int = tensor1.num_elements()//num_cores
+        var comps_remainder: Int = tensor1.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
+                var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
+                )
+
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        @parameter
+        fn remainder_closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
+            var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
+            result_tensor.store[width=opt_nelts](
+                i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
+            )
+        vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+
+
+    fn _math_func_compare_2_tensors[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[DType.bool, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        var num_cores: Int = num_physical_cores()
+        var comps_per_core: Int = tensor1.num_elements()//num_cores
+        var comps_remainder: Int = tensor1.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
+                var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
+                )
+
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        @parameter
+        fn remainder_closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
+            var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
+            result_tensor.store[width=opt_nelts](
+                i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
+            )
+        vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+        
+
+
+    fn _math_func_is[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            DType.bool, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        var num_cores: Int =  num_physical_cores()
+        var comps_per_core: Int = tensor.num_elements()//num_cores
+        var comps_remainder: Int = tensor.num_elements()%num_cores
+        var remainder_offset: Int = num_cores * comps_per_core
+        @parameter
+        fn par_closure(j:Int):
+            @parameter
+            fn closure[simdwidth: Int](i: Int):
+                var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
+                result_tensor.store[width=opt_nelts](
+                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
+                )
+
+            vectorize[closure, opt_nelts](comps_per_core)
+        parallelize[par_closure]()
+        @parameter
+        fn remainder_closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
+            result_tensor.store[width=opt_nelts](
+                i+remainder_offset, func[dtype, opt_nelts](simd_data)
+            )
+        vectorize[remainder_closure, opt_nelts](comps_remainder)
+        return result_tensor
+
+
+    fn _math_func_simd_int[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data = tensor.load[width=opt_nelts](i)
+
+            result_tensor.store[width=opt_nelts](
+                i, func[dtype, opt_nelts](simd_data, intval)
+            )
+
+        vectorize[closure, opt_nelts](tensor.num_elements())
         return result_tensor
 
 struct Naive(Backend):

--- a/numojo/_math_funcs.mojo
+++ b/numojo/_math_funcs.mojo
@@ -9,9 +9,53 @@ trait Backend:
     """
     A trait that defines backends for calculations in the rest of the library.
     """
-
+    
     fn __init__(inout self:Self):
        pass
+
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+            tensor3: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        pass
+    
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], simd: SIMD[dtype,1]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor.
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor.
+            tensor2: A tensor.
+            simd: A SIMD[dtype,1] value to be added
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        pass
 
     fn _math_func_1_tensor_in_one_tensor_out[
         dtype: DType,
@@ -86,198 +130,248 @@ trait Backend:
     ](self:Self,tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
         ...
 
-struct VectorizedVerbose(Backend):
-    """
-    Vectorized Backend Struct.
+# struct VectorizedVerbose(Backend):
+#     """
+#     Vectorized Backend Struct.
 
-    Defualt Numojo computation backend takes advantage of SIMD.
-    Uses defualt simdwidth.
-    """
+#     Defualt Numojo computation backend takes advantage of SIMD.
+#     Uses defualt simdwidth.
+#     """
     
-    fn __init__(inout self:Self):
-       pass
+#     fn __init__(inout self:Self):
+#        pass
 
+#     fn _math_func_fma[
+#         dtype: DType,
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+#         """
+#         Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
+
+#         Constraints:
+#             Both tensors must have the same shape
+
+#         Parameters:
+#             dtype: The element type.
+
+#         Args:
+#             tensor1: A tensor
+#             tensor2: A tensor
+#             tensor3: A tensor
+
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+
+#         if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         for i in range(
+#             0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
+#         ):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i)
+#             var simd_data2 = tensor2.load[width=opt_nelts](i)
+#             var simd_data3 = tensor3.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, SIMD.fma(simd_data1,simd_data2,simd_data3)
+#             )
+
+#         if tensor1.num_elements() % opt_nelts != 0:
+#             for i in range(
+#                 opt_nelts * (tensor1.num_elements() // opt_nelts),
+#                 tensor1.num_elements(),
+#             ):
+#                 var simd_data1 = tensor1.load[width=1](i)
+#                 var simd_data2 = tensor2.load[width=1](i)
+#                 var simd_data3 = tensor3.load[width=1](i)
+#                 result_tensor.store[width=1](
+#                     i, SIMD.fma(simd_data1, simd_data2, simd_data3)
+#                 )
+#         return result_tensor
 
     
-    fn _math_func_1_tensor_in_one_tensor_out[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-            type, simd_w
-        ],
-    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
-        """
-        Apply a SIMD function of one variable and one return to a tensor
+#     fn _math_func_1_tensor_in_one_tensor_out[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+#             type, simd_w
+#         ],
+#     ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+#         """
+#         Apply a SIMD function of one variable and one return to a tensor
 
-        Parameters:
-            dtype: The element type.
-            func: the SIMD function to to apply.
+#         Parameters:
+#             dtype: The element type.
+#             func: the SIMD function to to apply.
 
-        Args:
-            tensor: A tensor
+#         Args:
+#             tensor: A tensor
 
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        for i in range(
-            0, opt_nelts * (tensor.num_elements() // opt_nelts), opt_nelts
-        ):
-            var simd_data = tensor.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data)
-            )
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         for i in range(
+#             0, opt_nelts * (tensor.num_elements() // opt_nelts), opt_nelts
+#         ):
+#             var simd_data = tensor.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data)
+#             )
 
-        if tensor.num_elements() % opt_nelts != 0:
-            for i in range(
-                opt_nelts * (tensor.num_elements() // opt_nelts),
-                tensor.num_elements(),
-            ):
-                var simd_data = func[dtype, 1](tensor.load[width=1](i))
-                result_tensor.store[width=1](i, simd_data)
-        return result_tensor
-
-
-    fn _math_func_2_tensor_in_one_tensor_out[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
-        """
-        Apply a SIMD function of two variable and one return to a tensor
-
-        Constraints:
-            Both tensors must have the same shape
-
-        Parameters:
-            dtype: The element type.
-            func: the SIMD function to to apply.
-
-        Args:
-            tensor1: A tensor
-            tensor2: A tensor
-
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
-
-        if tensor1.shape() != tensor2.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        for i in range(
-            0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
-        ):
-            var simd_data1 = tensor1.load[width=opt_nelts](i)
-            var simd_data2 = tensor2.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data1, simd_data2)
-            )
-
-        if tensor1.num_elements() % opt_nelts != 0:
-            for i in range(
-                opt_nelts * (tensor1.num_elements() // opt_nelts),
-                tensor1.num_elements(),
-            ):
-                var simd_data1 = tensor1.load[width=1](i)
-                var simd_data2 = tensor2.load[width=1](i)
-                result_tensor.store[width=1](
-                    i, func[dtype, 1](simd_data1, simd_data2)
-                )
-        return result_tensor
+#         if tensor.num_elements() % opt_nelts != 0:
+#             for i in range(
+#                 opt_nelts * (tensor.num_elements() // opt_nelts),
+#                 tensor.num_elements(),
+#             ):
+#                 var simd_data = func[dtype, 1](tensor.load[width=1](i))
+#                 result_tensor.store[width=1](i, simd_data)
+#         return result_tensor
 
 
-    fn _math_func_compare_2_tensors[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
-        if tensor1.shape() != tensor2.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        for i in range(
-            0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
-        ):
-            var simd_data1 = tensor1.load[width=opt_nelts](i)
-            var simd_data2 = tensor2.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data1, simd_data2)
-            )
+#     fn _math_func_2_tensor_in_one_tensor_out[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (
+#             SIMD[type, simd_w], SIMD[type, simd_w]
+#         ) -> SIMD[type, simd_w],
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+#         """
+#         Apply a SIMD function of two variable and one return to a tensor
 
-        if tensor1.num_elements() % opt_nelts != 0:
-            for i in range(
-                opt_nelts * (tensor1.num_elements() // opt_nelts),
-                tensor1.num_elements(),
-            ):
-                var simd_data1 = tensor1.load[width=1](i)
-                var simd_data2 = tensor2.load[width=1](i)
-                result_tensor.store[width=1](
-                    i, func[dtype, 1](simd_data1, simd_data2)
-                )
-        return result_tensor
+#         Constraints:
+#             Both tensors must have the same shape
 
+#         Parameters:
+#             dtype: The element type.
+#             func: the SIMD function to to apply.
 
-    fn _math_func_is[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-            DType.bool, simd_w
-        ],
-    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        for i in range(
-            0, opt_nelts * (tensor.num_elements() // opt_nelts), opt_nelts
-        ):
-            var simd_data = tensor.load[width=opt_nelts](i)
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data)
-            )
+#         Args:
+#             tensor1: A tensor
+#             tensor2: A tensor
 
-        if tensor.num_elements() % opt_nelts != 0:
-            for i in range(
-                opt_nelts * (tensor.num_elements() // opt_nelts),
-                tensor.num_elements(),
-            ):
-                var simd_data = func[dtype, 1](tensor.load[width=1](i))
-                result_tensor.store[width=1](i, simd_data)
-        return result_tensor
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+
+#         if tensor1.shape() != tensor2.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         for i in range(
+#             0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
+#         ):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i)
+#             var simd_data2 = tensor2.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data1, simd_data2)
+#             )
+
+#         if tensor1.num_elements() % opt_nelts != 0:
+#             for i in range(
+#                 opt_nelts * (tensor1.num_elements() // opt_nelts),
+#                 tensor1.num_elements(),
+#             ):
+#                 var simd_data1 = tensor1.load[width=1](i)
+#                 var simd_data2 = tensor2.load[width=1](i)
+#                 result_tensor.store[width=1](
+#                     i, func[dtype, 1](simd_data1, simd_data2)
+#                 )
+#         return result_tensor
 
 
-    fn _math_func_simd_int[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
-            type, simd_w
-        ],
-    ](self:Self,tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        for i in range(
-            0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
-        ):
-            var simd_data1 = tensor1.load[width=opt_nelts](i)
+#     fn _math_func_compare_2_tensors[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (
+#             SIMD[type, simd_w], SIMD[type, simd_w]
+#         ) -> SIMD[DType.bool, simd_w],
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+#         if tensor1.shape() != tensor2.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         for i in range(
+#             0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
+#         ):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i)
+#             var simd_data2 = tensor2.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data1, simd_data2)
+#             )
 
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data1, intval)
-            )
+#         if tensor1.num_elements() % opt_nelts != 0:
+#             for i in range(
+#                 opt_nelts * (tensor1.num_elements() // opt_nelts),
+#                 tensor1.num_elements(),
+#             ):
+#                 var simd_data1 = tensor1.load[width=1](i)
+#                 var simd_data2 = tensor2.load[width=1](i)
+#                 result_tensor.store[width=1](
+#                     i, func[dtype, 1](simd_data1, simd_data2)
+#                 )
+#         return result_tensor
 
-        if tensor1.num_elements() % opt_nelts != 0:
-            for i in range(
-                opt_nelts * (tensor1.num_elements() // opt_nelts),
-                tensor1.num_elements(),
-            ):
-                var simd_data1 = tensor1.load[width=1](i)
-                result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
-        return result_tensor
+
+#     fn _math_func_is[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+#             DType.bool, simd_w
+#         ],
+#     ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         for i in range(
+#             0, opt_nelts * (tensor.num_elements() // opt_nelts), opt_nelts
+#         ):
+#             var simd_data = tensor.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data)
+#             )
+
+#         if tensor.num_elements() % opt_nelts != 0:
+#             for i in range(
+#                 opt_nelts * (tensor.num_elements() // opt_nelts),
+#                 tensor.num_elements(),
+#             ):
+#                 var simd_data = func[dtype, 1](tensor.load[width=1](i))
+#                 result_tensor.store[width=1](i, simd_data)
+#         return result_tensor
+
+
+#     fn _math_func_simd_int[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+#             type, simd_w
+#         ],
+#     ](self:Self,tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         for i in range(
+#             0, opt_nelts * (tensor1.num_elements() // opt_nelts), opt_nelts
+#         ):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i)
+
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data1, intval)
+#             )
+
+#         if tensor1.num_elements() % opt_nelts != 0:
+#             for i in range(
+#                 opt_nelts * (tensor1.num_elements() // opt_nelts),
+#                 tensor1.num_elements(),
+#             ):
+#                 var simd_data1 = tensor1.load[width=1](i)
+#                 result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
+#         return result_tensor
 
 
 struct Vectorized(Backend):
     """
     Vectorized Backend Struct.
+    Parameters
+        unroll_factor: factor by which loops are unrolled.
 
     Defualt Numojo computation backend takes advantage of SIMD.
     Uses defualt simdwidth.
@@ -286,7 +380,81 @@ struct Vectorized(Backend):
     fn __init__(inout self:Self):
        pass
 
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
 
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+            tensor3: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            var simd_data3 = tensor3.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, SIMD.fma(simd_data1,simd_data2,simd_data3)
+            )
+
+        vectorize[closure, opt_nelts](tensor1.num_elements())
+        return result_tensor
+
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], simd: SIMD[dtype,1]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+            simd: A SIMD[dtype,1] value to be added
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        if tensor1.shape() != tensor2.shape():
+            with assert_raises():
+                raise "Shape Mismatch error shapes must match for this function"
+        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+        alias opt_nelts = simdwidthof[dtype]()
+        @parameter
+        fn closure[simdwidth: Int](i: Int):
+            var simd_data1 = tensor1.load[width=opt_nelts](i)
+            var simd_data2 = tensor2.load[width=opt_nelts](i)
+            # var simd_data3 = tensor3.load[width=opt_nelts](i)
+            result_tensor.store[width=opt_nelts](
+                i, SIMD.fma(simd_data1,simd_data2,simd)
+            )
+
+        vectorize[closure, opt_nelts](tensor1.num_elements())
+        return result_tensor
     
     fn _math_func_1_tensor_in_one_tensor_out[
         dtype: DType,
@@ -429,338 +597,614 @@ struct Vectorized(Backend):
         vectorize[closure, opt_nelts](tensor.num_elements())
         return result_tensor
 
+# struct VectorizedUnroll[unroll_factor:Int=1](Backend):
+#     """
+#     Vectorized Backend Struct.
+#     Parameters
+#         unroll_factor: factor by which loops are unrolled.
 
-struct VectorizedParallelized(Backend):
-    """
-    Vectorized and parrallelized Backend Struct.
-
-    Currently an order of magnitude slower than Vectorized for most functions.
-    No idea why, Not Reccomened for use at this Time.
-    """
+#     Defualt Numojo computation backend takes advantage of SIMD.
+#     Uses defualt simdwidth.
+#     """
     
-    fn __init__(inout self:Self):
-       pass
+#     fn __init__(inout self:Self):
+#        pass
 
+#     fn _math_func_fma[
+#         dtype: DType,
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+#         """
+#         Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
 
+#         Constraints:
+#             Both tensors must have the same shape
+
+#         Parameters:
+#             dtype: The element type.
+
+#         Args:
+#             tensor1: A tensor
+#             tensor2: A tensor
+#             tensor3: A tensor
+
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+
+#         if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         @parameter
+#         fn closure[simdwidth: Int](i: Int):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i)
+#             var simd_data2 = tensor2.load[width=opt_nelts](i)
+#             var simd_data3 = tensor3.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, SIMD.fma(simd_data1,simd_data2,simd_data3)
+#             )
+
+#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
+#         return result_tensor
     
-    fn _math_func_1_tensor_in_one_tensor_out[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-            type, simd_w
-        ],
-    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
-        """
-        Apply a SIMD function of one variable and one return to a tensor
+#     fn _math_func_1_tensor_in_one_tensor_out[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+#             type, simd_w
+#         ],
+#     ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+#         """
+#         Apply a SIMD function of one variable and one return to a tensor
 
-        Parameters:
-            dtype: The element type.
-            func: the SIMD function to to apply.
+#         Parameters:
+#             dtype: The element type.
+#             func: the SIMD function to to apply.
 
-        Args:
-            tensor: A tensor
+#         Args:
+#             tensor: A tensor
 
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        var num_cores: Int = num_physical_cores()
-        var comps_per_core: Int = tensor.num_elements()//num_cores
-        var comps_remainder: Int = tensor.num_elements()%num_cores
-        var remainder_offset: Int = num_cores * comps_per_core
-        @parameter
-        fn par_closure(j:Int):
-            @parameter
-            fn closure[simdwidth: Int](i: Int):
-                var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
-                result_tensor.store[width=opt_nelts](
-                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
-                )
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+       
+#         @parameter
+#         fn closure[simdwidth: Int](i: Int):
+#             var simd_data = tensor.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data)
+#             )
 
-            vectorize[closure, opt_nelts](comps_per_core)
-        parallelize[par_closure]()
-        @parameter
-        fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
-            result_tensor.store[width=opt_nelts](
-                i+remainder_offset, func[dtype, opt_nelts](simd_data)
-            )
-        vectorize[remainder_closure, opt_nelts](comps_remainder)
-        return result_tensor
+#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor.num_elements())
+        
+#         return result_tensor
 
 
-    fn _math_func_2_tensor_in_one_tensor_out[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
-        """
-        Apply a SIMD function of two variable and one return to a tensor
+#     fn _math_func_2_tensor_in_one_tensor_out[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (
+#             SIMD[type, simd_w], SIMD[type, simd_w]
+#         ) -> SIMD[type, simd_w],
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+#         """
+#         Apply a SIMD function of two variable and one return to a tensor
 
-        Constraints:
-            Both tensors must have the same shape
+#         Constraints:
+#             Both tensors must have the same shape
 
-        Parameters:
-            dtype: The element type.
-            func: the SIMD function to to apply.
+#         Parameters:
+#             dtype: The element type.
+#             func: the SIMD function to to apply.
 
-        Args:
-            tensor1: A tensor
-            tensor2: A tensor
+#         Args:
+#             tensor1: A tensor
+#             tensor2: A tensor
 
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
 
-        if tensor1.shape() != tensor2.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        var num_cores: Int = num_physical_cores()
-        var comps_per_core: Int = tensor1.num_elements()//num_cores
-        var comps_remainder: Int = tensor1.num_elements()%num_cores
-        var remainder_offset: Int = num_cores * comps_per_core
-        @parameter
-        fn par_closure(j:Int):
-            @parameter
-            fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
-                var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
-                result_tensor.store[width=opt_nelts](
-                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
-                )
+#         if tensor1.shape() != tensor2.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+        
+#         @parameter
+#         fn closure[simdwidth: Int](i: Int):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i)
+#             var simd_data2 = tensor2.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data1, simd_data2)
+#             )
 
-            vectorize[closure, opt_nelts](comps_per_core)
-        parallelize[par_closure]()
-        @parameter
-        fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
-            var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
-            result_tensor.store[width=opt_nelts](
-                i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
-            )
-        vectorize[remainder_closure, opt_nelts](comps_remainder)
-        return result_tensor
+#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
+#         return result_tensor
 
 
-    fn _math_func_compare_2_tensors[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
-        if tensor1.shape() != tensor2.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        var num_cores: Int = num_physical_cores()
-        var comps_per_core: Int = tensor1.num_elements()//num_cores
-        var comps_remainder: Int = tensor1.num_elements()%num_cores
-        var remainder_offset: Int = num_cores * comps_per_core
-        @parameter
-        fn par_closure(j:Int):
-            @parameter
-            fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
-                var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
-                result_tensor.store[width=opt_nelts](
-                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
-                )
+#     fn _math_func_compare_2_tensors[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (
+#             SIMD[type, simd_w], SIMD[type, simd_w]
+#         ) -> SIMD[DType.bool, simd_w],
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+#         if tensor1.shape() != tensor2.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+       
+#         @parameter
+#         fn closure[simdwidth: Int](i: Int):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i)
+#             var simd_data2 = tensor2.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data1, simd_data2)
+#             )
 
-            vectorize[closure, opt_nelts](comps_per_core)
-        parallelize[par_closure]()
-        @parameter
-        fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
-            var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
-            result_tensor.store[width=opt_nelts](
-                i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
-            )
-        vectorize[remainder_closure, opt_nelts](comps_remainder)
-        return result_tensor
+#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor1.num_elements())
+#         return result_tensor
         
 
 
-    fn _math_func_is[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-            DType.bool, simd_w
-        ],
-    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
-        alias opt_nelts = simdwidthof[dtype]()
-        var num_cores: Int =  num_physical_cores()
-        var comps_per_core: Int = tensor.num_elements()//num_cores
-        var comps_remainder: Int = tensor.num_elements()%num_cores
-        var remainder_offset: Int = num_cores * comps_per_core
-        @parameter
-        fn par_closure(j:Int):
-            @parameter
-            fn closure[simdwidth: Int](i: Int):
-                var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
-                result_tensor.store[width=opt_nelts](
-                    i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
-                )
+#     fn _math_func_is[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+#             DType.bool, simd_w
+#         ],
+#     ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         @parameter
+#         fn closure[simdwidth: Int](i: Int):
+#             var simd_data = tensor.load[width=opt_nelts](i)
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data)
+#             )
 
-            vectorize[closure, opt_nelts](comps_per_core)
-        parallelize[par_closure]()
-        @parameter
-        fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
-            result_tensor.store[width=opt_nelts](
-                i+remainder_offset, func[dtype, opt_nelts](simd_data)
-            )
-        vectorize[remainder_closure, opt_nelts](comps_remainder)
-        return result_tensor
+#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor.num_elements())
+#         return result_tensor
 
 
-    fn _math_func_simd_int[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
-            type, simd_w
-        ],
-    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+#     fn _math_func_simd_int[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+#             type, simd_w
+#         ],
+#     ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
 
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
-        alias opt_nelts = simdwidthof[dtype]()
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
         
-        @parameter
-        fn closure[simdwidth: Int](i: Int):
-            var simd_data = tensor.load[width=opt_nelts](i)
+#         @parameter
+#         fn closure[simdwidth: Int](i: Int):
+#             var simd_data = tensor.load[width=opt_nelts](i)
 
-            result_tensor.store[width=opt_nelts](
-                i, func[dtype, opt_nelts](simd_data, intval)
-            )
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data, intval)
+#             )
 
-        vectorize[closure, opt_nelts](tensor.num_elements())
-        return result_tensor
+#         vectorize[closure, opt_nelts,unroll_factor=unroll_factor](tensor.num_elements())
+#         return result_tensor
 
-struct Naive(Backend):
-    """
-    Naive Backend Struct.
+# struct VectorizedParallelized(Backend):
+#     """
+#     Vectorized and parrallelized Backend Struct.
 
-    Just loops for SIMD[Dtype, 1] equations
-    """
+#     Currently an order of magnitude slower than Vectorized for most functions.
+#     No idea why, Not Reccomened for use at this Time.
+#     """
     
-    fn __init__(inout self:Self):
-       pass
+#     fn __init__(inout self:Self):
+#        pass
+
+#     fn _math_func_fma[
+#         dtype: DType,
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+#         """
+#         Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
+
+#         Constraints:
+#             Both tensors must have the same shape
+
+#         Parameters:
+#             dtype: The element type.
+
+#         Args:
+#             tensor1: A tensor
+#             tensor2: A tensor
+#             tensor3: A tensor
+
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+
+#         if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         var num_cores: Int = num_physical_cores()
+#         var comps_per_core: Int = tensor1.num_elements()//num_cores
+#         var comps_remainder: Int = tensor1.num_elements()%num_cores
+#         var remainder_offset: Int = num_cores * comps_per_core
+#         @parameter
+#         fn par_closure(j:Int):
+#             @parameter
+#             fn closure[simdwidth: Int](i: Int):
+#                 var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
+#                 var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
+#                 var simd_data3 = tensor3.load[width=opt_nelts](i+comps_per_core*j)
+#                 result_tensor.store[width=opt_nelts](
+#                     i+comps_per_core*j, SIMD.fma(simd_data1,simd_data2,simd_data3)
+#                 )
+#             vectorize[closure, opt_nelts](comps_per_core)
+#         parallelize[par_closure]()
+#         @parameter
+#         fn remainder_closure[simdwidth: Int](i: Int):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
+#             var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
+#             var simd_data3 = tensor3.load[width=opt_nelts](i+remainder_offset)
+#             result_tensor.store[width=opt_nelts](
+#                 i+remainder_offset, SIMD.fma(simd_data1,simd_data2,simd_data3)
+#             )
+#         vectorize[remainder_closure, opt_nelts](comps_remainder)
+#         return result_tensor
+
+#     fn _math_func_1_tensor_in_one_tensor_out[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+#             type, simd_w
+#         ],
+#     ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+#         """
+#         Apply a SIMD function of one variable and one return to a tensor
+
+#         Parameters:
+#             dtype: The element type.
+#             func: the SIMD function to to apply.
+
+#         Args:
+#             tensor: A tensor
+
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         var num_cores: Int = num_physical_cores()
+#         var comps_per_core: Int = tensor.num_elements()//num_cores
+#         var comps_remainder: Int = tensor.num_elements()%num_cores
+#         var remainder_offset: Int = num_cores * comps_per_core
+#         @parameter
+#         fn par_closure(j:Int):
+#             @parameter
+#             fn closure[simdwidth: Int](i: Int):
+#                 var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
+#                 result_tensor.store[width=opt_nelts](
+#                     i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
+#                 )
+
+#             vectorize[closure, opt_nelts](comps_per_core)
+#         parallelize[par_closure]()
+#         @parameter
+#         fn remainder_closure[simdwidth: Int](i: Int):
+#             var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
+#             result_tensor.store[width=opt_nelts](
+#                 i+remainder_offset, func[dtype, opt_nelts](simd_data)
+#             )
+#         vectorize[remainder_closure, opt_nelts](comps_remainder)
+#         return result_tensor
 
 
+#     fn _math_func_2_tensor_in_one_tensor_out[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (
+#             SIMD[type, simd_w], SIMD[type, simd_w]
+#         ) -> SIMD[type, simd_w],
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+#         """
+#         Apply a SIMD function of two variable and one return to a tensor
+
+#         Constraints:
+#             Both tensors must have the same shape
+
+#         Parameters:
+#             dtype: The element type.
+#             func: the SIMD function to to apply.
+
+#         Args:
+#             tensor1: A tensor
+#             tensor2: A tensor
+
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+
+#         if tensor1.shape() != tensor2.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         var num_cores: Int = num_physical_cores()
+#         var comps_per_core: Int = tensor1.num_elements()//num_cores
+#         var comps_remainder: Int = tensor1.num_elements()%num_cores
+#         var remainder_offset: Int = num_cores * comps_per_core
+#         @parameter
+#         fn par_closure(j:Int):
+#             @parameter
+#             fn closure[simdwidth: Int](i: Int):
+#                 var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
+#                 var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
+#                 result_tensor.store[width=opt_nelts](
+#                     i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
+#                 )
+
+#             vectorize[closure, opt_nelts](comps_per_core)
+#         parallelize[par_closure]()
+#         @parameter
+#         fn remainder_closure[simdwidth: Int](i: Int):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
+#             var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
+#             result_tensor.store[width=opt_nelts](
+#                 i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
+#             )
+#         vectorize[remainder_closure, opt_nelts](comps_remainder)
+#         return result_tensor
+
+
+#     fn _math_func_compare_2_tensors[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (
+#             SIMD[type, simd_w], SIMD[type, simd_w]
+#         ) -> SIMD[DType.bool, simd_w],
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+#         if tensor1.shape() != tensor2.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         var num_cores: Int = num_physical_cores()
+#         var comps_per_core: Int = tensor1.num_elements()//num_cores
+#         var comps_remainder: Int = tensor1.num_elements()%num_cores
+#         var remainder_offset: Int = num_cores * comps_per_core
+#         @parameter
+#         fn par_closure(j:Int):
+#             @parameter
+#             fn closure[simdwidth: Int](i: Int):
+#                 var simd_data1 = tensor1.load[width=opt_nelts](i+comps_per_core*j)
+#                 var simd_data2 = tensor2.load[width=opt_nelts](i+comps_per_core*j)
+#                 result_tensor.store[width=opt_nelts](
+#                     i+comps_per_core*j, func[dtype, opt_nelts](simd_data1, simd_data2)
+#                 )
+
+#             vectorize[closure, opt_nelts](comps_per_core)
+#         parallelize[par_closure]()
+#         @parameter
+#         fn remainder_closure[simdwidth: Int](i: Int):
+#             var simd_data1 = tensor1.load[width=opt_nelts](i+remainder_offset)
+#             var simd_data2 = tensor2.load[width=opt_nelts](i+remainder_offset)
+#             result_tensor.store[width=opt_nelts](
+#                 i+remainder_offset, func[dtype, opt_nelts](simd_data1, simd_data2)
+#             )
+#         vectorize[remainder_closure, opt_nelts](comps_remainder)
+#         return result_tensor
+        
+
+
+#     fn _math_func_is[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+#             DType.bool, simd_w
+#         ],
+#     ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+#         var num_cores: Int =  num_physical_cores()
+#         var comps_per_core: Int = tensor.num_elements()//num_cores
+#         var comps_remainder: Int = tensor.num_elements()%num_cores
+#         var remainder_offset: Int = num_cores * comps_per_core
+#         @parameter
+#         fn par_closure(j:Int):
+#             @parameter
+#             fn closure[simdwidth: Int](i: Int):
+#                 var simd_data = tensor.load[width=opt_nelts](i+comps_per_core*j)
+#                 result_tensor.store[width=opt_nelts](
+#                     i+comps_per_core*j, func[dtype, opt_nelts](simd_data)
+#                 )
+
+#             vectorize[closure, opt_nelts](comps_per_core)
+#         parallelize[par_closure]()
+#         @parameter
+#         fn remainder_closure[simdwidth: Int](i: Int):
+#             var simd_data = tensor.load[width=opt_nelts](i+remainder_offset)
+#             result_tensor.store[width=opt_nelts](
+#                 i+remainder_offset, func[dtype, opt_nelts](simd_data)
+#             )
+#         vectorize[remainder_closure, opt_nelts](comps_remainder)
+#         return result_tensor
+
+
+#     fn _math_func_simd_int[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+#             type, simd_w
+#         ],
+#     ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+        
+#         @parameter
+#         fn closure[simdwidth: Int](i: Int):
+#             var simd_data = tensor.load[width=opt_nelts](i)
+
+#             result_tensor.store[width=opt_nelts](
+#                 i, func[dtype, opt_nelts](simd_data, intval)
+#             )
+
+#         vectorize[closure, opt_nelts](tensor.num_elements())
+#         return result_tensor
+
+# struct Naive(Backend):
+#     """
+#     Naive Backend Struct.
+
+#     Just loops for SIMD[Dtype, 1] equations
+#     """
     
-    fn _math_func_1_tensor_in_one_tensor_out[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-            type, simd_w
-        ],
-    ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
-        """
-        Apply a SIMD function of one variable and one return to a tensor
+#     fn __init__(inout self:Self):
+#        pass
 
-        Parameters:
-            dtype: The element type.
-            func: the SIMD function to to apply.
+#     fn _math_func_fma[
+#         dtype: DType,
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+#         """
+#         Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
 
-        Args:
-            tensor: A tensor
+#         Constraints:
+#             Both tensors must have the same shape
 
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+#         Parameters:
+#             dtype: The element type.
+
+#         Args:
+#             tensor1: A tensor
+#             tensor2: A tensor
+#             tensor3: A tensor
+
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+
+#         if tensor1.shape() != tensor2.shape() and tensor1.shape() != tensor3.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+#         alias opt_nelts = simdwidthof[dtype]()
+       
+#         for i in range(tensor1.num_elements()):
+#             var simd_data1 = tensor1.load[width=1](i)
+#             var simd_data2 = tensor2.load[width=1](i)
+#             var simd_data3 = tensor3.load[width=1](i)
+#             result_tensor.store[width=1](
+#                 i, SIMD.fma(simd_data1, simd_data2, simd_data3)
+#             )
+#         return result_tensor
+    
+#     fn _math_func_1_tensor_in_one_tensor_out[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+#             type, simd_w
+#         ],
+#     ](self: Self, tensor: Tensor[dtype]) -> Tensor[dtype]:
+#         """
+#         Apply a SIMD function of one variable and one return to a tensor
+
+#         Parameters:
+#             dtype: The element type.
+#             func: the SIMD function to to apply.
+
+#         Args:
+#             tensor: A tensor
+
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
         
-        for i in range(
-            tensor.num_elements()
-        ):
-            var simd_data = func[dtype, 1](tensor.load[width=1](i))
-            result_tensor.store[width=1](i, simd_data)
-        return result_tensor
+#         for i in range(
+#             tensor.num_elements()
+#         ):
+#             var simd_data = func[dtype, 1](tensor.load[width=1](i))
+#             result_tensor.store[width=1](i, simd_data)
+#         return result_tensor
 
 
-    fn _math_func_2_tensor_in_one_tensor_out[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
-        """
-        Apply a SIMD function of two variable and one return to a tensor
+#     fn _math_func_2_tensor_in_one_tensor_out[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (
+#             SIMD[type, simd_w], SIMD[type, simd_w]
+#         ) -> SIMD[type, simd_w],
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+#         """
+#         Apply a SIMD function of two variable and one return to a tensor
 
-        Constraints:
-            Both tensors must have the same shape
+#         Constraints:
+#             Both tensors must have the same shape
 
-        Parameters:
-            dtype: The element type.
-            func: the SIMD function to to apply.
+#         Parameters:
+#             dtype: The element type.
+#             func: the SIMD function to to apply.
 
-        Args:
-            tensor1: A tensor
-            tensor2: A tensor
+#         Args:
+#             tensor1: A tensor
+#             tensor2: A tensor
 
-        Returns:
-            A a new tensor that is tensor with the function func applied.
-        """
+#         Returns:
+#             A a new tensor that is tensor with the function func applied.
+#         """
 
-        if tensor1.shape() != tensor2.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
+#         if tensor1.shape() != tensor2.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor1.shape())
         
-        for i in range(tensor1.num_elements()):
-            var simd_data1 = tensor1.load[width=1](i)
-            var simd_data2 = tensor2.load[width=1](i)
-            result_tensor.store[width=1](
-                i, func[dtype, 1](simd_data1, simd_data2)
-            )
-        return result_tensor
+#         for i in range(tensor1.num_elements()):
+#             var simd_data1 = tensor1.load[width=1](i)
+#             var simd_data2 = tensor2.load[width=1](i)
+#             result_tensor.store[width=1](
+#                 i, func[dtype, 1](simd_data1, simd_data2)
+#             )
+#         return result_tensor
 
 
-    fn _math_func_compare_2_tensors[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
-    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
-        if tensor1.shape() != tensor2.shape():
-            with assert_raises():
-                raise "Shape Mismatch error shapes must match for this function"
-        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
+#     fn _math_func_compare_2_tensors[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (
+#             SIMD[type, simd_w], SIMD[type, simd_w]
+#         ) -> SIMD[DType.bool, simd_w],
+#     ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+#         if tensor1.shape() != tensor2.shape():
+#             with assert_raises():
+#                 raise "Shape Mismatch error shapes must match for this function"
+#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor1.shape())
         
-        for i in range(tensor1.num_elements()):
-            var simd_data1 = tensor1.load[width=1](i)
-            var simd_data2 = tensor2.load[width=1](i)
-            result_tensor.store[width=1](
-                i, func[dtype, 1](simd_data1, simd_data2)
-            )
-        return result_tensor
+#         for i in range(tensor1.num_elements()):
+#             var simd_data1 = tensor1.load[width=1](i)
+#             var simd_data2 = tensor2.load[width=1](i)
+#             result_tensor.store[width=1](
+#                 i, func[dtype, 1](simd_data1, simd_data2)
+#             )
+#         return result_tensor
 
 
-    fn _math_func_is[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
-            DType.bool, simd_w
-        ],
-    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-        var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
+#     fn _math_func_is[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+#             DType.bool, simd_w
+#         ],
+#     ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+#         var result_tensor: Tensor[DType.bool] = Tensor[DType.bool](tensor.shape())
         
 
-        for i in range(tensor.num_elements()):
-            var simd_data = func[dtype, 1](tensor.load[width=1](i))
-            result_tensor.store[width=1](i, simd_data)
-        return result_tensor
+#         for i in range(tensor.num_elements()):
+#             var simd_data = func[dtype, 1](tensor.load[width=1](i))
+#             result_tensor.store[width=1](i, simd_data)
+#         return result_tensor
 
 
-    fn _math_func_simd_int[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
-            type, simd_w
-        ],
-    ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
-        var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
+#     fn _math_func_simd_int[
+#         dtype: DType,
+#         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+#             type, simd_w
+#         ],
+#     ](self:Self,tensor: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+#         var result_tensor: Tensor[dtype] = Tensor[dtype](tensor.shape())
         
-        for i in range(tensor.num_elements()):
-            var simd_data1 = tensor.load[width=1](i)
-            result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
-        return result_tensor
+#         for i in range(tensor.num_elements()):
+#             var simd_data1 = tensor.load[width=1](i)
+#             result_tensor.store[width=1](i, func[dtype, 1](simd_data1, intval))
+#         return result_tensor

--- a/numojo/_math_funcs.mojo
+++ b/numojo/_math_funcs.mojo
@@ -275,7 +275,7 @@ struct VectorizedVerbose(Backend):
         return result_tensor
 
 
-struct _Vectorized(Backend):
+struct Vectorized(Backend):
     """
     Vectorized Backend Struct.
 
@@ -430,12 +430,12 @@ struct _Vectorized(Backend):
         return result_tensor
 
 
-struct Vectorized(Backend):#Parallelized(Backend):
+struct VectorizedParallelized(Backend):
     """
-    Vectorized Backend Struct.
+    Vectorized and parrallelized Backend Struct.
 
-    Defualt Numojo computation backend takes advantage of SIMD.
-    Uses defualt simdwidth.
+    Currently an order of magnitude slower than Vectorized for most functions.
+    No idea why, Not Reccomened for use at this Time.
     """
     
     fn __init__(inout self:Self):

--- a/numojo/arithmetic.mojo
+++ b/numojo/arithmetic.mojo
@@ -171,6 +171,53 @@ fn div[
         tensor1, tensor2
     )
 
+fn fma[
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
+](tensor1: Tensor[dtype], tensor2: Tensor[dtype],tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+    """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor.
+
+        Constraints:
+            Both tensors must have the same shape.
+
+        Parameters:
+            dtype: The element type.
+            backend: Sets utility function origin, defualts to `Vectorized`.
+
+        Args:
+            tensor1: A tensor.
+            tensor2: A tensor.
+            tensor3: A tensor.
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+    return backend()._math_func_fma(tensor1, tensor2, tensor3)
+
+fn fma[
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
+](tensor1: Tensor[dtype], tensor2: Tensor[dtype], simd: SIMD[dtype,1]) raises -> Tensor[dtype]:
+    """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor.
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            backend: Sets utility function origin, defualts to `Vectorized`.
+
+        Args:
+            tensor1: A tensor.
+            tensor2: A tensor.
+            simd: A SIMD[dtype,1] value to be added.
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+    return backend()._math_func_fma(tensor1, tensor2, simd)
 
 fn remainder[
     dtype: DType,

--- a/numojo/arithmetic.mojo
+++ b/numojo/arithmetic.mojo
@@ -245,26 +245,26 @@ fn cbrt[dtype: DType,
     return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.cbrt](tensor)
 
 
-fn pow[dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized](tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
-    """
-    Elementwise tensor to the power of intval.
+# fn pow[dtype: DType,
+#     backend: _mf.Backend = _mf.Vectorized](tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+#     """
+#     Elementwise tensor to the power of intval.
 
-    Constraints:
-        Both tensors must have the same shapes.
+#     Constraints:
+#         Both tensors must have the same shapes.
 
-    Parameters:
-        dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+#     Parameters:
+#         dtype: The element type.
+#         backend: Sets utility function origin, defualts to `Vectorized`.
 
-    Args:
-        tensor1: A tensor.
-        intval: An integer.
+#     Args:
+#         tensor1: A tensor.
+#         intval: An integer.
 
-    Returns:
-        A tensor equal to tensor**intval.
-    """
-    return backend()._math_func_simd_int[dtype, math.pow](tensor1, intval)
+#     Returns:
+#         A tensor equal to tensor**intval.
+#     """
+#     return backend()._math_func_simd_int[dtype, math.pow](tensor1, intval)
 
 
 fn rsqrt[dtype: DType,

--- a/numojo/arithmetic.mojo
+++ b/numojo/arithmetic.mojo
@@ -11,7 +11,9 @@ implements arithmetic functions
 
 
 fn add[
-    dtype: DType
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized,
+    
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Perform addition on two tensors.
@@ -21,6 +23,7 @@ fn add[
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor1: A tensor.
@@ -29,13 +32,14 @@ fn add[
     Returns:
         The elementwise sum of `tensor1` and`tensor2`.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.add](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.add](
         tensor1, tensor2
     )
 
 
 fn sub[
-    dtype: DType
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Perform subtraction on two tensors.
@@ -45,6 +49,7 @@ fn sub[
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor1: A tensor.
@@ -53,7 +58,7 @@ fn sub[
     Returns:
         The elementwise difference of `tensor1` and`tensor2`.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.sub](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.sub](
         tensor1, tensor2
     )
 
@@ -64,7 +69,8 @@ fn sub[
 
 
 fn copysign[
-    dtype: DType
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Copy the sign of the first tensor and apply it to the second tensor.
@@ -74,6 +80,7 @@ fn copysign[
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor1: A tensor.
@@ -82,13 +89,14 @@ fn copysign[
     Returns:
         The second tensor multipied by the sign of the first tensor.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.copysign](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.copysign](
         tensor1, tensor2
     )
 
 
 fn mod[
-    dtype: DType
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Elementwise modulo of tensor1 and tensor2.
@@ -98,6 +106,7 @@ fn mod[
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor1: A tensor.
@@ -106,13 +115,14 @@ fn mod[
     Returns:
         A tensor equal to tensor1%tensor2.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.mod](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.mod](
         tensor1, tensor2
     )
 
 
 fn mul[
-    dtype: DType
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Elementwise product of tensor1 and tensor2.
@@ -122,6 +132,7 @@ fn mul[
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor1: A tensor.
@@ -130,13 +141,14 @@ fn mul[
     Returns:
         A tensor equal to tensor1*tensor2.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.mul](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.mul](
         tensor1, tensor2
     )
 
 
 fn div[
-    dtype: DType
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Elementwise quotent of tensor1 and tensor2.
@@ -146,6 +158,7 @@ fn div[
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor1: A tensor.
@@ -154,13 +167,14 @@ fn div[
     Returns:
         A tensor equal to tensor1/tensor2.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.div](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.div](
         tensor1, tensor2
     )
 
 
 fn remainder[
-    dtype: DType
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Elementwise remainders of tensor.
@@ -170,6 +184,7 @@ fn remainder[
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor1: A tensor.
@@ -178,12 +193,13 @@ fn remainder[
     Returns:
         A tensor equal to tensor1//tensor2.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.remainder](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.remainder](
         tensor1, tensor2
     )
 
 
-fn reciprocal[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn reciprocal[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise reciprocals of tensor1 and tensor2.
 
@@ -192,6 +208,7 @@ fn reciprocal[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -199,7 +216,7 @@ fn reciprocal[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to 1/tensor.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.reciprocal](
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.reciprocal](
         tensor
     )
 
@@ -207,7 +224,8 @@ fn reciprocal[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
 # ===------------------------------------------------------------------------===#
 # Exponents/Roots
 # ===------------------------------------------------------------------------===#
-fn cbrt[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn cbrt[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise cuberoot of tensor.
 
@@ -216,6 +234,7 @@ fn cbrt[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -223,10 +242,11 @@ fn cbrt[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to tensor**(1/3).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.cbrt](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.cbrt](tensor)
 
 
-fn pow[dtype: DType](tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+fn pow[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
     """
     Elementwise tensor to the power of intval.
 
@@ -235,6 +255,7 @@ fn pow[dtype: DType](tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor1: A tensor.
@@ -243,15 +264,17 @@ fn pow[dtype: DType](tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
     Returns:
         A tensor equal to tensor**intval.
     """
-    return _mf._math_func_simd_int[dtype, math.pow](tensor1, intval)
+    return backend()._math_func_simd_int[dtype, math.pow](tensor1, intval)
 
 
-fn rsqrt[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn rsqrt[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise reciprocal squareroot of tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -259,15 +282,17 @@ fn rsqrt[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to 1/tensor**(1/2).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.rsqrt](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.rsqrt](tensor)
 
 
-fn sqrt[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn sqrt[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise squareroot of tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -275,15 +300,17 @@ fn sqrt[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to tensor**(1/2).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.sqrt](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.sqrt](tensor)
 
 
-fn exp2[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn exp2[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Calculate elementwise two to the power of tensor[i].
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -292,15 +319,17 @@ fn exp2[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
         A tensor with the shape of `tensor` with values equal to the
         2 to the power of the value in the original tensor at each position.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.exp2](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.exp2](tensor)
 
 
-fn exp[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn exp[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Calculate elementwise euler's constant(e) to the power of tensor[i].
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -309,15 +338,17 @@ fn exp[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
         A tensor with the shape of `tensor` with values equal to the
         e to the power of the value in the original tensor at each position.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.exp](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.exp](tensor)
 
 
-fn expm1[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn expm1[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Calculate elementwise euler's constant(e) to the power of tensor[i] minus1.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -326,13 +357,14 @@ fn expm1[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
         A tensor with the shape of `tensor` with values equal to the negative one plus
         e to the power of the value in the original tensor at each position.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.expm1](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.expm1](tensor)
 
 
 fn scalb[
-    dtype: DType
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.scalb](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.scalb](
         tensor1, tensor2
     )
 
@@ -342,12 +374,14 @@ fn scalb[
 # ===------------------------------------------------------------------------===#
 
 
-fn log[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn log[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise natural logarithm of tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -355,18 +389,20 @@ fn log[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to ln(tensor).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.log](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.log](tensor)
 
 
 alias ln = log
 
 
-fn log2[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn log2[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise logarithm base two of tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -374,15 +410,17 @@ fn log2[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to log_2(tensor).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.log2](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.log2](tensor)
 
 
-fn log10[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn log10[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise logarithm base ten of tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -390,15 +428,17 @@ fn log10[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to log_10(tensor).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.log10](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.log10](tensor)
 
 
-fn log1p[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn log1p[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise natural logarithm of 1 plus tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -406,7 +446,7 @@ fn log1p[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to ln(tensor+1).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.log1p](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.log1p](tensor)
 
 
 # ===------------------------------------------------------------------------===#
@@ -414,12 +454,14 @@ fn log1p[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn abs[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn abs[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise absolute value of tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -427,15 +469,17 @@ fn abs[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to abs(tensor).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.abs](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.abs](tensor)
 
 
-fn floor[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn floor[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise round down to nearest whole number of tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -443,15 +487,17 @@ fn floor[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to floor(tensor).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.floor](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.floor](tensor)
 
 
-fn ceil[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn ceil[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise round up to nearest whole number of tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -459,15 +505,17 @@ fn ceil[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to ceil(tensor).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.ceil](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.ceil](tensor)
 
 
-fn trunc[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn trunc[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise remove decimal value from float whole number of tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -475,15 +523,17 @@ fn trunc[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to trunc(tensor).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.trunc](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.trunc](tensor)
 
 
-fn round[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn round[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Elementwise  tensor.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: A tensor.
@@ -491,15 +541,17 @@ fn round[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         A tensor equal to trunc(tensor).
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.round](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.round](tensor)
 
 
-fn roundeven[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn roundeven[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Performs elementwise banker's rounding on the elements of a tensor.
 
     Parameters:
         dtype: The dtype of the input and output Tensor.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: Tensor to perform rounding on.
@@ -509,17 +561,19 @@ fn roundeven[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
 
     This rounding goes to the nearest integer with ties toward the nearest even integer.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.roundeven](
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.roundeven](
         tensor
     )
 
 
-fn round_half_down[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn round_half_down[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Rounds ties towards the smaller integer.
 
     Parameters:
         dtype: The dtype of the input and output Tensor.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: Tensor to perform rounding on.
@@ -527,17 +581,19 @@ fn round_half_down[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
     The elementwise rounding of x evaluating ties towards the smaller integer.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[
+    return backend()._math_func_1_tensor_in_one_tensor_out[
         dtype, math.round_half_down
     ](tensor)
 
 
-fn round_half_up[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn round_half_up[dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Rounds ties towards the larger integer.
 
     Parameters:
         dtype: The dtype of the input and output Tensor.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
         tensor: Tensor to perform rounding on.
@@ -545,19 +601,21 @@ fn round_half_up[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
     The elementwise rounding of x evaluating ties towards the larger integer.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.round_half_up](
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.round_half_up](
         tensor
     )
 
 
 fn nextafter[
-    dtype: DType
+    dtype: DType,
+    backend: _mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Computes the nextafter of the inputs.
 
     Parameters:
         dtype: The dtype of the input and output Tensor. Constraints: must be a floating-point type.
+        backend: Sets utility function origin, defualts to `Vectorized`.
 
 
     Args:
@@ -567,6 +625,6 @@ fn nextafter[
     Returns:
     The nextafter of the inputs.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.nextafter](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.nextafter](
         tensor1, tensor2
     )

--- a/numojo/check.mojo
+++ b/numojo/check.mojo
@@ -3,25 +3,25 @@ import . _math_funcs as _mf
 from tensor import Tensor
 
 
-fn is_power_of_2[dtype: DType](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    return _mf._math_func_is[dtype, math.is_power_of_2](tensor)
+fn is_power_of_2[dtype: DType,backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+    return backend()._math_func_is[dtype, math.is_power_of_2](tensor)
 
 
-fn is_even[dtype: DType](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    return _mf._math_func_is[dtype, math.is_even](tensor)
+fn is_even[dtype: DType,backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+    return backend()._math_func_is[dtype, math.is_even](tensor)
 
 
-fn is_odd[dtype: DType](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    return _mf._math_func_is[dtype, math.is_odd](tensor)
+fn is_odd[dtype: DType,backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+    return backend()._math_func_is[dtype, math.is_odd](tensor)
 
 
-fn isinf[dtype: DType](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    return _mf._math_func_is[dtype, math.isinf](tensor)
+fn isinf[dtype: DType,backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+    return backend()._math_func_is[dtype, math.isinf](tensor)
 
 
-fn isfinite[dtype: DType](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    return _mf._math_func_is[dtype, math.isfinite](tensor)
+fn isfinite[dtype: DType,backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+    return backend()._math_func_is[dtype, math.isfinite](tensor)
 
 
-fn isnan[dtype: DType](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    return _mf._math_func_is[dtype, math.isnan](tensor)
+fn isnan[dtype: DType,backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+    return backend()._math_func_is[dtype, math.isnan](tensor)

--- a/numojo/comparison.mojo
+++ b/numojo/comparison.mojo
@@ -11,13 +11,15 @@ implements comparison functions
 # Simple Elementwise Comparisons
 # ===------------------------------------------------------------------------===#
 fn greater[
-    dtype: DType
+    dtype: DType,
+    backend:_mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
     """
     Performs elementwise check of whether values in x are greater than values in y.
 
     Parameters:
         dtype: The dtype of the input Tensor.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor1: First Tensor to compare.
@@ -28,19 +30,22 @@ fn greater[
 
     An element of the result Tensor will be True if the corresponding element in x is greater than the corresponding element in y, and False otherwise.
     """
-    return _mf._math_func_compare_2_tensors[dtype, math.greater](
+    return backend()._math_func_compare_2_tensors[dtype, math.greater](
         tensor1, tensor2
     )
 
 
 fn greater_equal[
-    dtype: DType
+    dtype: DType,
+    backend:_mf.Backend = _mf.Vectorized
+    
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
     """
     Performs elementwise check of whether values in x are greater than or equal to values in y.
 
     Parameters:
         dtype: The dtype of the input Tensor.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor1: First Tensor to compare.
@@ -51,19 +56,21 @@ fn greater_equal[
 
     An element of the result Tensor will be True if the corresponding element in x is greater than or equal to the corresponding element in y, and False otherwise.
     """
-    return _mf._math_func_compare_2_tensors[dtype, math.greater_equal](
+    return backend()._math_func_compare_2_tensors[dtype, math.greater_equal](
         tensor1, tensor2
     )
 
 
 fn less[
-    dtype: DType
+    dtype: DType,
+    backend:_mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
     """
     Performs elementwise check of whether values in x are to values in y.
 
     Parameters:
         dtype: The dtype of the input Tensor.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor1: First Tensor to compare.
@@ -74,17 +81,19 @@ fn less[
 
     An element of the result Tensor will be True if the corresponding element in x is or equal to the corresponding element in y, and False otherwise.
     """
-    return _mf._math_func_compare_2_tensors[dtype, math.less](tensor1, tensor2)
+    return backend()._math_func_compare_2_tensors[dtype, math.less](tensor1, tensor2)
 
 
 fn less_equal[
-    dtype: DType
+    dtype: DType,
+    backend:_mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
     """
     Performs elementwise check of whether values in x are less than or equal to values in y.
 
     Parameters:
         dtype: The dtype of the input Tensor.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor1: First Tensor to compare.
@@ -95,19 +104,21 @@ fn less_equal[
 
     An element of the result Tensor will be True if the corresponding element in x is less than or equal to the corresponding element in y, and False otherwise.
     """
-    return _mf._math_func_compare_2_tensors[dtype, math.less_equal](
+    return backend()._math_func_compare_2_tensors[dtype, math.less_equal](
         tensor1, tensor2
     )
 
 
 fn equal[
-    dtype: DType
+    dtype: DType,
+    backend:_mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
     """
     Performs elementwise check of whether values in x are equal to values in y.
 
     Parameters:
         dtype: The dtype of the input Tensor.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor1: First Tensor to compare.
@@ -118,17 +129,19 @@ fn equal[
 
     An element of the result Tensor will be True if the corresponding element in x is equal to the corresponding element in y, and False otherwise.
     """
-    return _mf._math_func_compare_2_tensors[dtype, math.equal](tensor1, tensor2)
+    return backend()._math_func_compare_2_tensors[dtype, math.equal](tensor1, tensor2)
 
 
 fn not_equal[
-    dtype: DType
+    dtype: DType,
+    backend:_mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
     """
     Performs elementwise check of whether values in x are not equal to values in y.
 
     Parameters:
         dtype: The dtype of the input Tensor.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor1: First Tensor to compare.
@@ -139,6 +152,6 @@ fn not_equal[
 
     An element of the result Tensor will be True if the corresponding element in x is not equal to the corresponding element in y, and False otherwise.
     """
-    return _mf._math_func_compare_2_tensors[dtype, math.not_equal](
+    return backend()._math_func_compare_2_tensors[dtype, math.not_equal](
         tensor1, tensor2
     )

--- a/numojo/traits/backend.mojo
+++ b/numojo/traits/backend.mojo
@@ -1,0 +1,126 @@
+from tensor import Tensor
+
+trait Backend:
+    """
+    A trait that defines backends for calculations in the rest of the library.
+    """
+    
+    fn __init__(inout self:Self):
+       pass
+
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], tensor3: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+            tensor3: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        pass
+    
+    fn _math_func_fma[
+        dtype: DType,
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype], simd: SIMD[dtype,1]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD level fuse multipy add function of three variables and one return to a tensor.
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+
+        Args:
+            tensor1: A tensor.
+            tensor2: A tensor.
+            simd: A SIMD[dtype,1] value to be added
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        pass
+
+    fn _math_func_1_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[dtype]:
+        """
+        Apply a SIMD function of one variable and one return to a tensor
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+        ...
+
+
+    fn _math_func_2_tensor_in_one_tensor_out[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[type, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+        """
+        Apply a SIMD function of two variable and one return to a tensor
+
+        Constraints:
+            Both tensors must have the same shape
+
+        Parameters:
+            dtype: The element type.
+            func: the SIMD function to to apply.
+
+        Args:
+            tensor1: A tensor
+            tensor2: A tensor
+
+        Returns:
+            A a new tensor that is tensor with the function func applied.
+        """
+
+        ...
+
+    fn _math_func_compare_2_tensors[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (
+            SIMD[type, simd_w], SIMD[type, simd_w]
+        ) -> SIMD[DType.bool, simd_w],
+    ](self:Self,tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[DType.bool]:
+       ...
+
+    fn _math_func_is[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
+            DType.bool, simd_w
+        ],
+    ](self:Self,tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+        ...
+
+
+    fn _math_func_simd_int[
+        dtype: DType,
+        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+            type, simd_w
+        ],
+    ](self:Self,tensor1: Tensor[dtype], intval: Int) -> Tensor[dtype]:
+        ...

--- a/numojo/traits/tensor_traits.mojo
+++ b/numojo/traits/tensor_traits.mojo
@@ -1,0 +1,18 @@
+"""
+Tensor Traits will eventaully go here once we have our own version of tensor
+"""
+from tensor import Tensor
+
+# trait TensorLike:
+  
+#     fn __add__(self:Self, rhs:TensorLike)->Self:
+#         ...
+#     fn __add__(self:Self, rhs:Self)->Self:
+#         ...
+# trait TensorWeak:
+#     fn load[*, width: Int = 1](self: Self, index: Int) -> SIMD[type, $0]:
+#         ...
+#     fn store[*, width: Int = 1](inout self: Self, index: Int, val: SIMD[type, width]):
+#         ...
+#     fn shape
+

--- a/numojo/trig.mojo
+++ b/numojo/trig.mojo
@@ -1,6 +1,7 @@
 import math
 import . _math_funcs as _mf
 from tensor import Tensor
+from .arithmetic import sqrt, fma
 
 """
 implements trigonometry functions
@@ -170,7 +171,33 @@ fn hypot[
         tensor1, tensor2
     )
 
+fn hypot_fma[
+    dtype: DType,
+    backend:_mf.Backend = _mf.Vectorized
+](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
+    """
+    Apply hypot also known as hypotenuse which finds the longest section of a right triangle
+    given the other two sides.
 
+    Constraints:
+        Both tensors must have the same shapes.
+
+    Parameters:
+        dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
+
+    Args:
+        tensor1: A tensor.
+        tensor2: A tensor.
+
+    Returns:
+        The elementwise hypotenuse of `tensor1` and`tensor2`.
+    """
+    
+    
+    var tensor2_squared =fma[dtype,backend=backend](tensor2,tensor2,SIMD[dtype,1](0))
+    return sqrt[dtype,backend=backend](fma[dtype,backend=backend](tensor1,tensor1,tensor2_squared))
+    
 # ===------------------------------------------------------------------------===#
 # Inverse Hyperbolic Trig
 # ===------------------------------------------------------------------------===#

--- a/numojo/trig.mojo
+++ b/numojo/trig.mojo
@@ -10,12 +10,13 @@ implements trigonometry functions
 # ===------------------------------------------------------------------------===#
 
 
-fn acos[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn acos[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply acos also known as inverse cosine .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor.
@@ -23,15 +24,16 @@ fn acos[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise acos of `tensor` in radians.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.acos](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.acos](tensor)
 
 
-fn asin[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn asin[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply asin also known as inverse sine .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor.
@@ -39,15 +41,16 @@ fn asin[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise asin of `tensor` in radians.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.asin](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.asin](tensor)
 
 
-fn atan[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn atan[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply atan also known as inverse tangent .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor.
@@ -55,11 +58,12 @@ fn atan[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise atan of `tensor` in radians.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.atan](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.atan](tensor)
 
 
 fn atan2[
-    dtype: DType
+    dtype: DType,
+    backend:_mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Apply atan2 also known as inverse tangent.
@@ -70,6 +74,7 @@ fn atan2[
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor1: A tensor.
@@ -78,7 +83,7 @@ fn atan2[
     Returns:
         The elementwise atan2 of `tensor1` and`tensor2` in radians.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.atan2](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.atan2](
         tensor1, tensor2
     )
 
@@ -88,12 +93,13 @@ fn atan2[
 # ===------------------------------------------------------------------------===#
 
 
-fn cos[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn cos[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply cos also known as cosine.
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor assumed to be in radian.
@@ -101,15 +107,16 @@ fn cos[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise cos of `tensor`.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.cos](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.cos](tensor)
 
 
-fn sin[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn sin[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply sin also known as sine .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor assumed to be in radian.
@@ -117,15 +124,16 @@ fn sin[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise sin of `tensor`.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.sin](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.sin](tensor)
 
 
-fn tan[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn tan[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply tan also known as tangent .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor assumed to be in radian.
@@ -133,11 +141,12 @@ fn tan[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise tan of `tensor`.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.tan](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.tan](tensor)
 
 
 fn hypot[
-    dtype: DType
+    dtype: DType,
+    backend:_mf.Backend = _mf.Vectorized
 ](tensor1: Tensor[dtype], tensor2: Tensor[dtype]) raises -> Tensor[dtype]:
     """
     Apply hypot also known as hypotenuse which finds the longest section of a right triangle
@@ -148,6 +157,7 @@ fn hypot[
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor1: A tensor.
@@ -156,7 +166,7 @@ fn hypot[
     Returns:
         The elementwise hypotenuse of `tensor1` and`tensor2`.
     """
-    return _mf._math_func_2_tensor_in_one_tensor_out[dtype, math.hypot](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.hypot](
         tensor1, tensor2
     )
 
@@ -166,12 +176,13 @@ fn hypot[
 # ===------------------------------------------------------------------------===#
 
 
-fn acosh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn acosh[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply acosh also known as inverse hyperbolic cosine .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor.
@@ -179,15 +190,16 @@ fn acosh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise acosh of `tensor` in radians.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.acosh](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.acosh](tensor)
 
 
-fn asinh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn asinh[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply asinh also known as inverse hyperbolic sine .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor.
@@ -195,15 +207,16 @@ fn asinh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise asinh of `tensor` in radians.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.asinh](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.asinh](tensor)
 
 
-fn atanh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn atanh[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply atanh also known as inverse hyperbolic tangent .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor.
@@ -211,7 +224,7 @@ fn atanh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise atanh of `tensor` in radians.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.atanh](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.atanh](tensor)
 
 
 # ===------------------------------------------------------------------------===#
@@ -219,12 +232,13 @@ fn atanh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn cosh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn cosh[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply cosh also known as hyperbolic cosine .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor assumed to be in radian.
@@ -232,15 +246,16 @@ fn cosh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise cosh of `tensor`.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.cosh](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.cosh](tensor)
 
 
-fn sinh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn sinh[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply sin also known as hyperbolic sine .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor assumed to be in radian.
@@ -248,15 +263,16 @@ fn sinh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise sinh of `tensor`.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.sinh](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.sinh](tensor)
 
 
-fn tanh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
+fn tanh[dtype: DType, backend:_mf.Backend = _mf.Vectorized](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
     Apply tan also known as hyperbolic tangent .
 
     Parameters:
         dtype: The element type.
+        backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
         tensor: A tensor assumed to be in radian.
@@ -264,4 +280,4 @@ fn tanh[dtype: DType](tensor: Tensor[dtype]) -> Tensor[dtype]:
     Returns:
         The elementwise tanh of `tensor`.
     """
-    return _mf._math_func_1_tensor_in_one_tensor_out[dtype, math.tanh](tensor)
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.tanh](tensor)


### PR DESCRIPTION
Add interchangeable backends for basic math functions. Naive uses loops, Vectorized uses SIMD vectorization, Parallel uses parallelization(and contains the code for ParralelizedVectorized which was always slower than either Parrallelized or Vectorized). Vectorized is the default, and the backend can be passed as a parameter to each function.